### PR TITLE
Update how numMiddlePages works

### DIFF
--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -16,7 +16,8 @@ const Pagination = forwardRef(
       a11yTitle,
       numItems,
       numEdgePages = 1, // number of pages at each edge of page indices
-      numMiddlePages = 3, // number of page controls in the middle
+      // number of page controls in the middle
+      numMiddlePages: numMiddlePagesProp = 3,
       onChange,
       page: pageProp,
       show: showProp,
@@ -54,9 +55,15 @@ const Pagination = forwardRef(
       totalPages,
     );
 
-    if (numMiddlePages < 1) {
-      console.warn(`Property "numMiddlePages" should not be < 1.`);
-    }
+    let numMiddlePages;
+    if (numMiddlePagesProp < 1) {
+      numMiddlePages = 1;
+      console.warn(
+        // eslint-disable-next-line max-len
+        `Property "numMiddlePages" should not be < 1. One middle page button will be shown. Set "numMiddlePages" >= 1 to remove this warning.`,
+      );
+    } else numMiddlePages = numMiddlePagesProp;
+
     let startingMiddlePages;
     // odd
     if (numMiddlePages % 2)

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -16,7 +16,7 @@ const Pagination = forwardRef(
       a11yTitle,
       numItems,
       numEdgePages = 1, // number of pages at each edge of page indices
-      numMiddlePages = 1, // number of pages surrounding the active page
+      numMiddlePages = 3, // number of page controls in the middle
       onChange,
       page: pageProp,
       show: showProp,
@@ -54,18 +54,29 @@ const Pagination = forwardRef(
       totalPages,
     );
 
-    const middlePagesBegin = Math.max(
-      Math.min(
-        activePage - numMiddlePages,
-        totalPages - numEdgePages - numMiddlePages * 2 - 1,
-      ),
-      numEdgePages + 2,
-    );
+    if (numMiddlePages < 1) {
+      console.warn(`Property "numMiddlePages" should not be < 1.`);
+    }
+    let startingMiddlePages;
+    // odd
+    if (numMiddlePages % 2)
+      startingMiddlePages = Math.min(
+        activePage - Math.floor(numMiddlePages / 2),
+        totalPages - numEdgePages - numMiddlePages - 1,
+      );
+    // even, cannot split equally around active page
+    // let extra page appear on middlePagesEnd instead
+    else
+      startingMiddlePages = Math.min(
+        activePage - Math.floor(numMiddlePages / 2) + 1,
+        totalPages - numEdgePages - numMiddlePages,
+      );
 
+    const middlePagesBegin = Math.max(startingMiddlePages, numEdgePages + 2);
     const middlePagesEnd = Math.min(
       Math.max(
-        activePage + numMiddlePages,
-        numEdgePages + numMiddlePages * 2 + 2,
+        activePage + Math.floor(numMiddlePages / 2),
+        numEdgePages + numMiddlePages + 2,
       ),
       endPages.length > 0 ? endPages[0] - 2 : totalPages - 1,
     );

--- a/src/js/components/Pagination/stories/Simple.js
+++ b/src/js/components/Pagination/stories/Simple.js
@@ -29,10 +29,12 @@ const Simple = () => {
           <Pagination numItems={237} page={10} numEdgePages={2} />
         </Box>
         <Box>
-          <Text>
-            numMiddlePages = 2 (number of pages to left/right of middle page)
-          </Text>
-          <Pagination numItems={237} page={10} numMiddlePages={2} />
+          <Text>numMiddlePages = 4 (number of pages in the middle)</Text>
+          <Pagination numItems={237} page={10} numMiddlePages={4} />
+        </Box>
+        <Box>
+          <Text>numMiddlePages = 5 (number of pages in the middle)</Text>
+          <Pagination numItems={237} page={10} numMiddlePages={5} />
         </Box>
         <Box>
           <Text>numEdgePages = 0</Text>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
numMiddlePages should refer to the entire group of page buttons, not divided across either side. If the number provided by the user is even, allow place the "extra" page on the right side (moving forward).

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
