### PR TITLE
Adjust theming structure to theme.pagination.button

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -69,11 +69,15 @@ const basicStyle = props => css`
 `;
 
 // build up CSS from basic to specific based on the supplied sub-object paths
-const kindStyle = ({ colorValue, themePaths, theme }) => {
+const kindStyle = ({ colorValue, kind, themePaths, theme }) => {
   const styles = [];
 
+  // caller has specified a themeObj to use for styling
+  // relevant for cases like pagination which looks to theme.pagination.button
+  const themeObj = typeof kind === 'object' ? kind : undefined;
+
   themePaths.base.forEach(themePath => {
-    let obj = theme.button;
+    let obj = themeObj || theme.button;
     if (themePath) {
       const parts = themePath.split('.');
       while (obj && parts.length) obj = obj[parts.shift()];
@@ -83,8 +87,16 @@ const kindStyle = ({ colorValue, themePaths, theme }) => {
     }
   });
 
+  // do the styling from the root of the object if caller passes one
+  if (!themePaths.base.length && themeObj) {
+    const obj = themeObj;
+    if (obj) {
+      styles.push(kindPartStyles(obj, theme, colorValue));
+    }
+  }
+
   themePaths.hover.forEach(themePath => {
-    let obj = theme.button;
+    let obj = themeObj || theme.button;
     if (themePath) {
       const parts = themePath.split('.');
       while (obj && parts.length) obj = obj[parts.shift()];

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -12057,8 +12057,8 @@ exports[`DataTable should apply pagination styling 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c17 g {
@@ -12080,6 +12080,40 @@ exports[`DataTable should apply pagination styling 1`] = `
 .c17 *[FILL-RULE],
 .c17 *[fill*="#"],
 .c17 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c21 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c21 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c21 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -12236,8 +12270,6 @@ exports[`DataTable should apply pagination styling 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -12297,8 +12329,8 @@ exports[`DataTable should apply pagination styling 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -12447,7 +12479,6 @@ exports[`DataTable should apply pagination styling 1`] = `
 .c16 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c14 {
@@ -14127,7 +14158,7 @@ exports[`DataTable should apply pagination styling 1`] = `
               aria-label="Go to previous page"
               class="c15 c16"
               disabled=""
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
@@ -14155,7 +14186,7 @@ exports[`DataTable should apply pagination styling 1`] = `
               aria-current="page"
               aria-label="Go to page 1"
               class="c19 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               1
@@ -14170,7 +14201,7 @@ exports[`DataTable should apply pagination styling 1`] = `
             <button
               aria-label="Go to page 2"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               2
@@ -14185,12 +14216,12 @@ exports[`DataTable should apply pagination styling 1`] = `
             <button
               aria-label="Go to next page"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c21"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -14217,8 +14248,8 @@ exports[`DataTable should paginate 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c17 g {
@@ -14240,6 +14271,40 @@ exports[`DataTable should paginate 1`] = `
 .c17 *[FILL-RULE],
 .c17 *[fill*="#"],
 .c17 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c21 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c21 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c21 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -14394,8 +14459,6 @@ exports[`DataTable should paginate 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -14455,8 +14518,8 @@ exports[`DataTable should paginate 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -14605,7 +14668,6 @@ exports[`DataTable should paginate 1`] = `
 .c16 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c14 {
@@ -16279,7 +16341,7 @@ exports[`DataTable should paginate 1`] = `
               aria-label="Go to previous page"
               class="c15 c16"
               disabled=""
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
@@ -16307,7 +16369,7 @@ exports[`DataTable should paginate 1`] = `
               aria-current="page"
               aria-label="Go to page 1"
               class="c19 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               1
@@ -16322,7 +16384,7 @@ exports[`DataTable should paginate 1`] = `
             <button
               aria-label="Go to page 2"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               2
@@ -16337,12 +16399,12 @@ exports[`DataTable should paginate 1`] = `
             <button
               aria-label="Go to next page"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c21"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -16369,8 +16431,8 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c17 g {
@@ -16392,6 +16454,40 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
 .c17 *[FILL-RULE],
 .c17 *[fill*="#"],
 .c17 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c21 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c21 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c21 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -16546,8 +16642,6 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -16607,8 +16701,8 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -16757,7 +16851,6 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
 .c16 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c14 {
@@ -17315,7 +17408,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
               aria-label="Go to previous page"
               class="c15 c16"
               disabled=""
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
@@ -17343,7 +17436,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
               aria-current="page"
               aria-label="Go to page 1"
               class="c19 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               1
@@ -17358,7 +17451,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-label="Go to page 2"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               2
@@ -17373,7 +17466,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-label="Go to page 3"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               3
@@ -17388,7 +17481,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-label="Go to page 4"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               4
@@ -17403,7 +17496,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-label="Go to page 5"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               5
@@ -17418,7 +17511,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-label="Go to page 6"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               6
@@ -17433,7 +17526,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-label="Go to page 7"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               7
@@ -17448,12 +17541,12 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-label="Go to next page"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c21"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -17480,8 +17573,8 @@ exports[`DataTable should render new data when page changes 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c17 g {
@@ -17503,6 +17596,40 @@ exports[`DataTable should render new data when page changes 1`] = `
 .c17 *[FILL-RULE],
 .c17 *[fill*="#"],
 .c17 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c21 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c21 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c21 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -17657,8 +17784,6 @@ exports[`DataTable should render new data when page changes 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -17718,8 +17843,8 @@ exports[`DataTable should render new data when page changes 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -17868,7 +17993,6 @@ exports[`DataTable should render new data when page changes 1`] = `
 .c16 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c14 {
@@ -19542,7 +19666,7 @@ exports[`DataTable should render new data when page changes 1`] = `
               aria-label="Go to previous page"
               class="c15 c16"
               disabled=""
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
@@ -19570,7 +19694,7 @@ exports[`DataTable should render new data when page changes 1`] = `
               aria-current="page"
               aria-label="Go to page 1"
               class="c19 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               1
@@ -19585,7 +19709,7 @@ exports[`DataTable should render new data when page changes 1`] = `
             <button
               aria-label="Go to page 2"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               2
@@ -19600,12 +19724,12 @@ exports[`DataTable should render new data when page changes 1`] = `
             <button
               aria-label="Go to next page"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c21"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -23470,8 +23594,8 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-              kind="pagination"
+              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+              kind="[object Object]"
               type="button"
             >
               <svg
@@ -23497,8 +23621,8 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-              kind="pagination"
+              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+              kind="[object Object]"
               type="button"
             >
               1
@@ -23513,8 +23637,8 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 fwVZOK StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-              kind="pagination"
+              class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+              kind="[object Object]"
               type="button"
             >
               2
@@ -23529,14 +23653,14 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 jOMQGR StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
+              class="StyledButtonKind-sc-1vhfpnt-0 fVgacz StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
               disabled=""
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 eMJPUV"
+                class="StyledIcon-ofa7kd-0 dEeaTZ"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -23563,8 +23687,8 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c17 g {
@@ -23586,6 +23710,40 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
 .c17 *[FILL-RULE],
 .c17 *[fill*="#"],
 .c17 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c21 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c21 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c21 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -23740,8 +23898,6 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -23801,8 +23957,8 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -23951,7 +24107,6 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
 .c16 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c14 {
@@ -25625,7 +25780,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
               aria-label="Go to previous page"
               class="c15 c16"
               disabled=""
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
@@ -25653,7 +25808,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
               aria-current="page"
               aria-label="Go to page 1"
               class="c19 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               1
@@ -25668,7 +25823,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
             <button
               aria-label="Go to page 2"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               2
@@ -25683,12 +25838,12 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
             <button
               aria-label="Go to next page"
               class="c20 c16"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c21"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -25738,6 +25893,40 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 .c16 *[FILL-RULE],
 .c16 *[fill*="#"],
 .c16 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c20 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c20 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c20 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c20 *[stroke*="#"],
+.c20 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c20 *[fill-rule],
+.c20 *[FILL-RULE],
+.c20 *[fill*="#"],
+.c20 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -25936,8 +26125,8 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -25997,8 +26186,6 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -26085,7 +26272,6 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 .c15 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c13 {
@@ -27591,7 +27777,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
             <button
               aria-label="Go to previous page"
               class="c14 c15"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
@@ -27618,7 +27804,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
             <button
               aria-label="Go to page 1"
               class="c14 c15"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               1
@@ -27634,7 +27820,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
               aria-current="page"
               aria-label="Go to page 2"
               class="c18 c15"
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               2
@@ -27651,12 +27837,12 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
               aria-label="Go to next page"
               class="c19 c15"
               disabled=""
-              kind="pagination"
+              kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c16"
+                class="c20"
                 viewBox="0 0 24 24"
               >
                 <polyline

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -2109,8 +2109,8 @@ exports[`List events should apply pagination styling 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c12 g {
@@ -2132,6 +2132,40 @@ exports[`List events should apply pagination styling 1`] = `
 .c12 *[FILL-RULE],
 .c12 *[fill*="#"],
 .c12 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c17 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c17 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c17 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c17 *[stroke*="#"],
+.c17 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*="#"],
+.c17 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -2297,8 +2331,6 @@ exports[`List events should apply pagination styling 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -2358,8 +2390,8 @@ exports[`List events should apply pagination styling 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -2466,7 +2498,6 @@ exports[`List events should apply pagination styling 1`] = `
 .c11 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c9 {
@@ -2644,7 +2675,7 @@ exports[`List events should apply pagination styling 1`] = `
             aria-label="Go to previous page"
             class="c10 c11"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -2672,7 +2703,7 @@ exports[`List events should apply pagination styling 1`] = `
             aria-current="page"
             aria-label="Go to page 1"
             class="c14 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -2687,7 +2718,7 @@ exports[`List events should apply pagination styling 1`] = `
           <button
             aria-label="Go to page 2"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -2702,7 +2733,7 @@ exports[`List events should apply pagination styling 1`] = `
           <button
             aria-label="Go to page 3"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -2717,7 +2748,7 @@ exports[`List events should apply pagination styling 1`] = `
           <button
             aria-label="Go to page 4"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -2732,7 +2763,7 @@ exports[`List events should apply pagination styling 1`] = `
           <button
             aria-label="Go to page 5"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -2759,7 +2790,7 @@ exports[`List events should apply pagination styling 1`] = `
           <button
             aria-label="Go to page 10"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -2774,12 +2805,12 @@ exports[`List events should apply pagination styling 1`] = `
           <button
             aria-label="Go to next page"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c17"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -2805,8 +2836,8 @@ exports[`List events should paginate 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c12 g {
@@ -2828,6 +2859,40 @@ exports[`List events should paginate 1`] = `
 .c12 *[FILL-RULE],
 .c12 *[fill*="#"],
 .c12 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c17 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c17 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c17 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c17 *[stroke*="#"],
+.c17 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*="#"],
+.c17 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -2991,8 +3056,6 @@ exports[`List events should paginate 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -3052,8 +3115,8 @@ exports[`List events should paginate 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3160,7 +3223,6 @@ exports[`List events should paginate 1`] = `
 .c11 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c9 {
@@ -3332,7 +3394,7 @@ exports[`List events should paginate 1`] = `
             aria-label="Go to previous page"
             class="c10 c11"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -3360,7 +3422,7 @@ exports[`List events should paginate 1`] = `
             aria-current="page"
             aria-label="Go to page 1"
             class="c14 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -3375,7 +3437,7 @@ exports[`List events should paginate 1`] = `
           <button
             aria-label="Go to page 2"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -3390,7 +3452,7 @@ exports[`List events should paginate 1`] = `
           <button
             aria-label="Go to page 3"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -3405,7 +3467,7 @@ exports[`List events should paginate 1`] = `
           <button
             aria-label="Go to page 4"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -3420,7 +3482,7 @@ exports[`List events should paginate 1`] = `
           <button
             aria-label="Go to page 5"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -3447,7 +3509,7 @@ exports[`List events should paginate 1`] = `
           <button
             aria-label="Go to page 10"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -3462,12 +3524,12 @@ exports[`List events should paginate 1`] = `
           <button
             aria-label="Go to next page"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c17"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -3493,8 +3555,8 @@ exports[`List events should render correct num items per page (step) 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c12 g {
@@ -3516,6 +3578,40 @@ exports[`List events should render correct num items per page (step) 1`] = `
 .c12 *[FILL-RULE],
 .c12 *[fill*="#"],
 .c12 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c16 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c16 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c16 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c16 *[stroke*="#"],
+.c16 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*="#"],
+.c16 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -3673,8 +3769,6 @@ exports[`List events should render correct num items per page (step) 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -3734,8 +3828,8 @@ exports[`List events should render correct num items per page (step) 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3842,7 +3936,6 @@ exports[`List events should render correct num items per page (step) 1`] = `
 .c11 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c9 {
@@ -4034,7 +4127,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
             aria-label="Go to previous page"
             class="c10 c11"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4062,7 +4155,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
             aria-current="page"
             aria-label="Go to page 1"
             class="c14 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -4077,7 +4170,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-label="Go to page 2"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -4092,7 +4185,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-label="Go to page 3"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -4107,7 +4200,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-label="Go to page 4"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -4122,7 +4215,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-label="Go to page 5"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -4137,7 +4230,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-label="Go to page 6"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             6
@@ -4152,7 +4245,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-label="Go to page 7"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             7
@@ -4167,12 +4260,12 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-label="Go to next page"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c16"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -4198,8 +4291,8 @@ exports[`List events should render new data when page changes 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c12 g {
@@ -4221,6 +4314,40 @@ exports[`List events should render new data when page changes 1`] = `
 .c12 *[FILL-RULE],
 .c12 *[fill*="#"],
 .c12 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c17 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c17 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c17 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c17 *[stroke*="#"],
+.c17 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*="#"],
+.c17 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4384,8 +4511,6 @@ exports[`List events should render new data when page changes 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -4445,8 +4570,8 @@ exports[`List events should render new data when page changes 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -4553,7 +4678,6 @@ exports[`List events should render new data when page changes 1`] = `
 .c11 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c9 {
@@ -4725,7 +4849,7 @@ exports[`List events should render new data when page changes 1`] = `
             aria-label="Go to previous page"
             class="c10 c11"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4753,7 +4877,7 @@ exports[`List events should render new data when page changes 1`] = `
             aria-current="page"
             aria-label="Go to page 1"
             class="c14 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -4768,7 +4892,7 @@ exports[`List events should render new data when page changes 1`] = `
           <button
             aria-label="Go to page 2"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -4783,7 +4907,7 @@ exports[`List events should render new data when page changes 1`] = `
           <button
             aria-label="Go to page 3"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -4798,7 +4922,7 @@ exports[`List events should render new data when page changes 1`] = `
           <button
             aria-label="Go to page 4"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -4813,7 +4937,7 @@ exports[`List events should render new data when page changes 1`] = `
           <button
             aria-label="Go to page 5"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -4840,7 +4964,7 @@ exports[`List events should render new data when page changes 1`] = `
           <button
             aria-label="Go to page 10"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -4855,12 +4979,12 @@ exports[`List events should render new data when page changes 1`] = `
           <button
             aria-label="Go to next page"
             class="c15 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c17"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -4958,8 +5082,8 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4985,8 +5109,8 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -5001,8 +5125,8 @@ exports[`List events should render new data when page changes 2`] = `
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 fwVZOK StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -5016,8 +5140,8 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -5031,8 +5155,8 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -5046,8 +5170,8 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -5073,8 +5197,8 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 10"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -5088,8 +5212,8 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -5368,8 +5492,8 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -5416,7 +5540,6 @@ exports[`List events should show correct item index when "show" is a number 1`] 
 .c11 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c9 {
@@ -5586,7 +5709,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           <button
             aria-label="Go to previous page"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -5613,7 +5736,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           <button
             aria-label="Go to page 1"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -5629,7 +5752,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
             aria-current="page"
             aria-label="Go to page 2"
             class="c14 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -5644,7 +5767,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           <button
             aria-label="Go to page 3"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -5659,7 +5782,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           <button
             aria-label="Go to page 4"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -5674,7 +5797,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           <button
             aria-label="Go to page 5"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -5701,7 +5824,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           <button
             aria-label="Go to page 10"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -5716,7 +5839,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           <button
             aria-label="Go to next page"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -5995,8 +6118,8 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -6043,7 +6166,6 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 .c11 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c9 {
@@ -6213,7 +6335,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
           <button
             aria-label="Go to previous page"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -6240,7 +6362,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
           <button
             aria-label="Go to page 1"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -6255,7 +6377,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
           <button
             aria-label="Go to page 2"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -6271,7 +6393,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
             aria-current="page"
             aria-label="Go to page 3"
             class="c14 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -6286,7 +6408,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
           <button
             aria-label="Go to page 4"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -6301,7 +6423,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
           <button
             aria-label="Go to page 5"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -6328,7 +6450,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
           <button
             aria-label="Go to page 10"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -6343,7 +6465,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
           <button
             aria-label="Go to next page"
             class="c10 c11"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg

--- a/src/js/components/Pagination/PageControl.js
+++ b/src/js/components/Pagination/PageControl.js
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
 
 import { Text } from '../Text';
 import { StyledPaginationButton, StyledContainer } from './StyledPageControl';
 
 export const PageControl = ({ control, separator, ...rest }) => {
+  const theme = useContext(ThemeContext);
+
   return (
     <StyledContainer as="li">
       {separator ? (
@@ -16,7 +19,7 @@ export const PageControl = ({ control, separator, ...rest }) => {
         <StyledPaginationButton
           a11yTitle={`Go to page ${control}`}
           fill
-          kind="pagination"
+          kind={theme.pagination.button}
           label={control}
           {...rest}
         />

--- a/src/js/components/Pagination/StyledPageControl.js
+++ b/src/js/components/Pagination/StyledPageControl.js
@@ -32,7 +32,6 @@ const sizeStyle = props => {
 export const StyledPaginationButton = styled(Button)`
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
   ${props => sizeStyle(props).content};
 `;
 

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -131,8 +131,8 @@ exports[`Pagination should allow user to control page via state with page +
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -239,7 +239,6 @@ exports[`Pagination should allow user to control page via state with page +
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -297,7 +296,7 @@ exports[`Pagination should allow user to control page via state with page +
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -324,7 +323,7 @@ exports[`Pagination should allow user to control page via state with page +
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -340,7 +339,7 @@ exports[`Pagination should allow user to control page via state with page +
             aria-current="page"
             aria-label="Go to page 2"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -355,7 +354,7 @@ exports[`Pagination should allow user to control page via state with page +
           <button
             aria-label="Go to page 3"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -370,7 +369,7 @@ exports[`Pagination should allow user to control page via state with page +
           <button
             aria-label="Go to page 4"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -385,7 +384,7 @@ exports[`Pagination should allow user to control page via state with page +
           <button
             aria-label="Go to page 5"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -412,7 +411,7 @@ exports[`Pagination should allow user to control page via state with page +
           <button
             aria-label="Go to page 24"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -427,7 +426,7 @@ exports[`Pagination should allow user to control page via state with page +
           <button
             aria-label="Go to next page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -458,8 +457,8 @@ exports[`Pagination should apply custom theme 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c8 g {
@@ -481,6 +480,40 @@ exports[`Pagination should apply custom theme 1`] = `
 .c8 *[FILL-RULE],
 .c8 *[fill*="#"],
 .c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c13 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c13 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c13 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -578,8 +611,6 @@ exports[`Pagination should apply custom theme 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -639,8 +670,8 @@ exports[`Pagination should apply custom theme 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -747,7 +778,6 @@ exports[`Pagination should apply custom theme 1`] = `
 .c7 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c5 {
@@ -811,7 +841,7 @@ exports[`Pagination should apply custom theme 1`] = `
             aria-label="Go to previous page"
             class="c6 c7"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -839,7 +869,7 @@ exports[`Pagination should apply custom theme 1`] = `
             aria-current="page"
             aria-label="Go to page 1"
             class="c10 c7"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -854,7 +884,7 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-label="Go to page 2"
             class="c11 c7"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -869,7 +899,7 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-label="Go to page 3"
             class="c11 c7"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -884,7 +914,7 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-label="Go to page 4"
             class="c11 c7"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -899,7 +929,7 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-label="Go to page 5"
             class="c11 c7"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -926,7 +956,7 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-label="Go to page 24"
             class="c11 c7"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -941,12 +971,12 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-label="Go to next page"
             class="c11 c7"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c8"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -995,6 +1025,40 @@ exports[`Pagination should disable next button if on last page 1`] = `
 .c7 *[FILL-RULE],
 .c7 *[fill*="#"],
 .c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1154,8 +1218,8 @@ exports[`Pagination should disable next button if on last page 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -1215,8 +1279,6 @@ exports[`Pagination should disable next button if on last page 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -1261,7 +1323,6 @@ exports[`Pagination should disable next button if on last page 1`] = `
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -1319,7 +1380,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -1346,7 +1407,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -1373,7 +1434,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-label="Go to page 20"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             20
@@ -1388,7 +1449,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-label="Go to page 21"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             21
@@ -1403,7 +1464,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-label="Go to page 22"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             22
@@ -1418,7 +1479,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-label="Go to page 23"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             23
@@ -1434,7 +1495,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
             aria-current="page"
             aria-label="Go to page 24"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -1451,12 +1512,12 @@ exports[`Pagination should disable next button if on last page 1`] = `
             aria-label="Go to next page"
             class="c11 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -1483,8 +1544,8 @@ exports[`Pagination should disable previous and next controls when numItems
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c7 g {
@@ -1597,8 +1658,6 @@ exports[`Pagination should disable previous and next controls when numItems
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -1658,8 +1717,8 @@ exports[`Pagination should disable previous and next controls when numItems
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -1706,7 +1765,6 @@ exports[`Pagination should disable previous and next controls when numItems
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -1766,7 +1824,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-label="Go to previous page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -1794,7 +1852,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-current="page"
             aria-label="Go to page 1"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -1811,7 +1869,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-label="Go to next page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -1843,8 +1901,8 @@ exports[`Pagination should disable previous and next controls when numItems
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c7 g {
@@ -1957,8 +2015,6 @@ exports[`Pagination should disable previous and next controls when numItems
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -2003,7 +2059,6 @@ exports[`Pagination should disable previous and next controls when numItems
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -2063,7 +2118,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-label="Go to previous page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -2091,7 +2146,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-label="Go to next page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -2123,8 +2178,8 @@ exports[`Pagination should disable previous and next controls when numItems
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c7 g {
@@ -2237,8 +2292,6 @@ exports[`Pagination should disable previous and next controls when numItems
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -2298,8 +2351,8 @@ exports[`Pagination should disable previous and next controls when numItems
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -2346,7 +2399,6 @@ exports[`Pagination should disable previous and next controls when numItems
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -2406,7 +2458,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-label="Go to previous page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -2434,7 +2486,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-current="page"
             aria-label="Go to page 1"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -2451,7 +2503,7 @@ exports[`Pagination should disable previous and next controls when numItems
             aria-label="Go to next page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -2482,8 +2534,8 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c7 g {
@@ -2505,6 +2557,40 @@ exports[`Pagination should disable previous button if on first page 1`] = `
 .c7 *[FILL-RULE],
 .c7 *[fill*="#"],
 .c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -2602,8 +2688,6 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -2663,8 +2747,8 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -2771,7 +2855,6 @@ exports[`Pagination should disable previous button if on first page 1`] = `
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -2831,7 +2914,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
             aria-label="Go to previous page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -2859,7 +2942,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
             aria-current="page"
             aria-label="Go to page 1"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -2874,7 +2957,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-label="Go to page 2"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -2889,7 +2972,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-label="Go to page 3"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -2904,7 +2987,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-label="Go to page 4"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -2919,7 +3002,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-label="Go to page 5"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -2946,7 +3029,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-label="Go to page 24"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -2961,12 +3044,12 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-label="Go to next page"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -3115,8 +3198,8 @@ exports[`Pagination should display next page of results when "next" is
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3223,7 +3306,6 @@ exports[`Pagination should display next page of results when "next" is
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -3281,7 +3363,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -3308,7 +3390,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -3324,7 +3406,7 @@ exports[`Pagination should display next page of results when "next" is
             aria-current="page"
             aria-label="Go to page 2"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -3339,7 +3421,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-label="Go to page 3"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -3354,7 +3436,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-label="Go to page 4"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -3369,7 +3451,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-label="Go to page 5"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -3396,7 +3478,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-label="Go to page 24"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -3411,7 +3493,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-label="Go to next page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -3454,8 +3536,8 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -3481,8 +3563,8 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -3497,8 +3579,8 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 fwVZOK StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -3512,8 +3594,8 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -3527,8 +3609,8 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -3542,8 +3624,8 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -3569,8 +3651,8 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -3584,8 +3666,8 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -3739,8 +3821,8 @@ exports[`Pagination should display page 'n' of results when "page n" is
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3847,7 +3929,6 @@ exports[`Pagination should display page 'n' of results when "page n" is
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -3905,7 +3986,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -3932,7 +4013,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -3948,7 +4029,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
             aria-current="page"
             aria-label="Go to page 2"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -3963,7 +4044,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
           <button
             aria-label="Go to page 3"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -3978,7 +4059,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
           <button
             aria-label="Go to page 4"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -3993,7 +4074,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
           <button
             aria-label="Go to page 5"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -4020,7 +4101,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
           <button
             aria-label="Go to page 24"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -4035,7 +4116,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
           <button
             aria-label="Go to next page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4249,8 +4330,8 @@ exports[`Pagination should display previous page of results when "previous" is
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -4297,7 +4378,6 @@ exports[`Pagination should display previous page of results when "previous" is
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -4355,7 +4435,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4382,7 +4462,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -4398,7 +4478,7 @@ exports[`Pagination should display previous page of results when "previous" is
             aria-current="page"
             aria-label="Go to page 2"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -4413,7 +4493,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-label="Go to page 3"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -4428,7 +4508,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-label="Go to page 4"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -4443,7 +4523,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-label="Go to page 5"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -4470,7 +4550,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-label="Go to page 24"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -4485,7 +4565,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-label="Go to next page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4528,8 +4608,8 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4555,8 +4635,8 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -4571,8 +4651,8 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 fwVZOK StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -4586,8 +4666,8 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -4601,8 +4681,8 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -4616,8 +4696,8 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -4643,8 +4723,8 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -4658,8 +4738,8 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cLIEIn"
-            kind="pagination"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -4691,8 +4771,8 @@ exports[`Pagination should display the correct last page based on items length
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c7 g {
@@ -4714,6 +4794,40 @@ exports[`Pagination should display the correct last page based on items length
 .c7 *[FILL-RULE],
 .c7 *[fill*="#"],
 .c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4811,8 +4925,6 @@ exports[`Pagination should display the correct last page based on items length
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -4872,8 +4984,8 @@ exports[`Pagination should display the correct last page based on items length
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -4980,7 +5092,6 @@ exports[`Pagination should display the correct last page based on items length
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -5040,7 +5151,7 @@ exports[`Pagination should display the correct last page based on items length
             aria-label="Go to previous page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -5068,7 +5179,7 @@ exports[`Pagination should display the correct last page based on items length
             aria-current="page"
             aria-label="Go to page 1"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -5083,7 +5194,7 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-label="Go to page 2"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -5098,7 +5209,7 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-label="Go to page 3"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -5113,7 +5224,7 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-label="Go to page 4"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             4
@@ -5128,7 +5239,7 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-label="Go to page 5"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             5
@@ -5155,7 +5266,7 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-label="Go to page 24"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -5170,12 +5281,12 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-label="Go to next page"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -5383,8 +5494,8 @@ exports[`Pagination should render correct numEdgePages 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -5431,7 +5542,6 @@ exports[`Pagination should render correct numEdgePages 1`] = `
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -5489,7 +5599,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -5516,7 +5626,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -5531,7 +5641,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 2"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -5546,7 +5656,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 3"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -5573,7 +5683,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 9"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             9
@@ -5589,7 +5699,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
             aria-current="page"
             aria-label="Go to page 10"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -5604,7 +5714,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 11"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             11
@@ -5631,7 +5741,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 22"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             22
@@ -5646,7 +5756,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 23"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             23
@@ -5661,7 +5771,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to page 24"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -5676,7 +5786,7 @@ exports[`Pagination should render correct numEdgePages 1`] = `
           <button
             aria-label="Go to next page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -5889,8 +5999,8 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -5937,7 +6047,6 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -5995,7 +6104,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -6022,7 +6131,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -6049,7 +6158,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
           <button
             aria-label="Go to page 9"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             9
@@ -6065,7 +6174,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
             aria-current="page"
             aria-label="Go to page 10"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -6080,7 +6189,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
           <button
             aria-label="Go to page 11"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             11
@@ -6095,7 +6204,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
           <button
             aria-label="Go to page 12"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             12
@@ -6122,7 +6231,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
           <button
             aria-label="Go to page 24"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -6137,7 +6246,7 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
           <button
             aria-label="Go to next page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -6350,8 +6459,8 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -6398,7 +6507,6 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -6456,7 +6564,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -6483,7 +6591,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -6510,7 +6618,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to page 8"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             8
@@ -6525,7 +6633,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to page 9"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             9
@@ -6541,7 +6649,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
             aria-current="page"
             aria-label="Go to page 10"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -6556,7 +6664,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to page 11"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             11
@@ -6571,7 +6679,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to page 12"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             12
@@ -6598,7 +6706,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to page 24"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -6613,7 +6721,7 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
           <button
             aria-label="Go to next page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -6644,8 +6752,8 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #000000;
-  stroke: #000000;
+  fill: #666666;
+  stroke: #666666;
 }
 
 .c7 g {
@@ -6667,6 +6775,40 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
 .c7 *[FILL-RULE],
 .c7 *[fill*="#"],
 .c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6764,8 +6906,6 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -6825,8 +6965,8 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -6933,7 +7073,6 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -6993,7 +7132,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
             aria-label="Go to previous page"
             class="c5 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -7021,7 +7160,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
             aria-current="page"
             aria-label="Go to page 1"
             class="c9 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -7036,7 +7175,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
           <button
             aria-label="Go to page 2"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             2
@@ -7051,7 +7190,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
           <button
             aria-label="Go to page 3"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             3
@@ -7078,7 +7217,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
           <button
             aria-label="Go to page 24"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             24
@@ -7093,12 +7232,12 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
           <button
             aria-label="Go to next page"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -7148,6 +7287,40 @@ exports[`Pagination should set page to last page if page prop > total possible
 .c7 *[FILL-RULE],
 .c7 *[fill*="#"],
 .c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7307,8 +7480,8 @@ exports[`Pagination should set page to last page if page prop > total possible
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  background: #33333310;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -7368,8 +7541,6 @@ exports[`Pagination should set page to last page if page prop > total possible
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
-  opacity: 0.3;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -7414,7 +7585,6 @@ exports[`Pagination should set page to last page if page prop > total possible
 .c6 {
   padding: 4px;
   border-radius: 4px;
-  border-width: 0;
 }
 
 .c4 {
@@ -7472,7 +7642,7 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-label="Go to previous page"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
@@ -7499,7 +7669,7 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-label="Go to page 1"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             1
@@ -7526,7 +7696,7 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-label="Go to page 6"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             6
@@ -7541,7 +7711,7 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-label="Go to page 7"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             7
@@ -7556,7 +7726,7 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-label="Go to page 8"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             8
@@ -7571,7 +7741,7 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-label="Go to page 9"
             class="c5 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             9
@@ -7587,7 +7757,7 @@ exports[`Pagination should set page to last page if page prop > total possible
             aria-current="page"
             aria-label="Go to page 10"
             class="c10 c6"
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             10
@@ -7604,12 +7774,12 @@ exports[`Pagination should set page to last page if page prop > total possible
             aria-label="Go to next page"
             class="c11 c6"
             disabled=""
-            kind="pagination"
+            kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <polyline

--- a/src/js/components/Pagination/stories/Custom.js
+++ b/src/js/components/Pagination/stories/Custom.js
@@ -4,10 +4,26 @@ import { Box, Grommet, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
 import { FormPreviousLink, FormNextLink } from 'grommet-icons';
+import { ThemeContext } from 'styled-components';
+import { hpe } from 'grommet-theme-hpe';
 import { Pagination } from '../Pagination';
 
 const customTheme = deepMerge(grommet, {
   pagination: {
+    button: {
+      color: 'text-strong',
+      active: {
+        background: {
+          color: 'salmon',
+        },
+        color: 'text',
+      },
+      hover: {
+        background: {
+          color: 'skyblue',
+        },
+      },
+    },
     controls: {
       gap: 'xxsmall',
     },
@@ -16,23 +32,11 @@ const customTheme = deepMerge(grommet, {
       previous: FormPreviousLink,
     },
   },
-  button: {
-    pagination: {
-      color: 'text-strong',
-    },
-    active: {
-      background: {
-        color: 'salmon',
-      },
-      color: 'text',
-    },
-    hover: {
-      pagination: {
-        background: {
-          color: 'skyblue',
-        },
-      },
-    },
+});
+
+const secondTheme = deepMerge(hpe, {
+  pagination: {
+    button: 'secondary',
   },
 });
 
@@ -41,6 +45,11 @@ export const Custom = () => (
     <Box align="start" pad="small" gap="small">
       <Text>Custom Theme</Text>
       <Pagination numItems={237} />
+
+      <Text>Reference Button Kind secondary by string with HPE theme</Text>
+      <ThemeContext.Extend value={secondTheme}>
+        <Pagination numItems={237} />
+      </ThemeContext.Extend>
     </Box>
   </Grommet>
 );

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -470,10 +470,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   },
       //   extend: undefined,
       // },
-      pagination: {
-        color: 'text-strong',
-        border: undefined,
-      },
       active: {
         background: 'active-background',
         //   border: undefined,
@@ -493,21 +489,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //   primary: {},
         //   secondary: {},
       },
-      hover: {
-        pagination: {
-          background: {
-            color: 'background-contrast',
-          },
-          color: undefined,
-        },
-        // background: undefined,
-        // border: undefined,
-        // color: undefined,
-        // extend: undefined,
-        // default: {},
-        // primary: {},
-        // secondary: {},
-      },
+      // hover: {
+      //   background: undefined,
+      //   border: undefined,
+      //   color: undefined,
+      //   extend: undefined,
+      //   default: {},
+      //   primary: {},
+      //   secondary: {},
+      // },
       padding: {
         vertical: `${baseSpacing / 4 - borderWidth}px`,
         horizontal: `${baseSpacing - borderWidth}px`,
@@ -964,6 +954,20 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   // any box props,
       //   // extend: undefined,
       // },
+      button: {
+        color: 'text-strong',
+        active: {
+          background: {
+            color: 'active-background',
+          },
+        },
+        hover: {
+          background: {
+            color: 'background-contrast',
+          },
+          color: undefined,
+        },
+      },
       // control: {
       //   // extend: undefined,
       //   size: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Keep pagination theming within the pagination object by allowing button kind to accept an object directing towards a different theme object.

Modifications needed to be made to Button and StyledButtonKind to know where to look (instead of looking into theme.button). The main difference is that when we are looking at a different theme object, we want to look into the root of the object, as opposed to button kinds that typically take the form of `button.default`, etc. Logic was added to check that "if kind is an object, look into the root of the object"

#### Where should the reviewer start?
src/js/components/Pagination/PageControl.js

#### What testing has been done on this PR?
Tested in storybook

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
