### PR TITLE
Adjust pagination control padding to flex based on borders for button states.

### DIFF
--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -12481,6 +12481,10 @@ exports[`DataTable should apply pagination styling 1`] = `
   border-radius: 4px;
 }
 
+.c16:hover {
+  padding: 4px;
+}
+
 .c14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -14670,6 +14674,10 @@ exports[`DataTable should paginate 1`] = `
   border-radius: 4px;
 }
 
+.c16:hover {
+  padding: 4px;
+}
+
 .c14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -16853,6 +16861,10 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border-radius: 4px;
 }
 
+.c16:hover {
+  padding: 4px;
+}
+
 .c14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -17993,6 +18005,10 @@ exports[`DataTable should render new data when page changes 1`] = `
 .c16 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c16:hover {
+  padding: 4px;
 }
 
 .c14 {
@@ -23594,7 +23610,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
               kind="[object Object]"
               type="button"
             >
@@ -23621,7 +23637,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
               kind="[object Object]"
               type="button"
             >
@@ -23637,7 +23653,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+              class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
               kind="[object Object]"
               type="button"
             >
@@ -23653,7 +23669,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 fVgacz StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+              class="StyledButtonKind-sc-1vhfpnt-0 fVgacz StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
               disabled=""
               kind="[object Object]"
               type="button"
@@ -24107,6 +24123,10 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
 .c16 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c16:hover {
+  padding: 4px;
 }
 
 .c14 {
@@ -26272,6 +26292,10 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 .c15 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c15:hover {
+  padding: 4px;
 }
 
 .c13 {

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -12084,7 +12084,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   stroke: none;
 }
 
-.c21 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12095,25 +12095,25 @@ exports[`DataTable should apply pagination styling 1`] = `
   stroke: #000000;
 }
 
-.c21 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c21 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c21 *[stroke*="#"],
-.c21 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c21 *[fill-rule],
-.c21 *[FILL-RULE],
-.c21 *[fill*="#"],
-.c21 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -12374,7 +12374,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   border: 0;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12406,31 +12406,31 @@ exports[`DataTable should apply pagination styling 1`] = `
   flex: 1 0 auto;
 }
 
-.c20 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c20:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -12481,7 +12481,12 @@ exports[`DataTable should apply pagination styling 1`] = `
   border-radius: 4px;
 }
 
-.c16:hover {
+.c20 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c20:hover {
   padding: 4px;
 }
 
@@ -14189,7 +14194,7 @@ exports[`DataTable should apply pagination styling 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c19 c16"
+              class="c19 c20"
               kind="[object Object]"
               type="button"
             >
@@ -14204,7 +14209,7 @@ exports[`DataTable should apply pagination styling 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -14219,13 +14224,13 @@ exports[`DataTable should apply pagination styling 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c21"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -14279,7 +14284,7 @@ exports[`DataTable should paginate 1`] = `
   stroke: none;
 }
 
-.c21 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -14290,25 +14295,25 @@ exports[`DataTable should paginate 1`] = `
   stroke: #000000;
 }
 
-.c21 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c21 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c21 *[stroke*="#"],
-.c21 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c21 *[fill-rule],
-.c21 *[FILL-RULE],
-.c21 *[fill*="#"],
-.c21 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -14567,7 +14572,7 @@ exports[`DataTable should paginate 1`] = `
   border: 0;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -14599,31 +14604,31 @@ exports[`DataTable should paginate 1`] = `
   flex: 1 0 auto;
 }
 
-.c20 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c20:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -14674,7 +14679,12 @@ exports[`DataTable should paginate 1`] = `
   border-radius: 4px;
 }
 
-.c16:hover {
+.c20 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c20:hover {
   padding: 4px;
 }
 
@@ -16376,7 +16386,7 @@ exports[`DataTable should paginate 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c19 c16"
+              class="c19 c20"
               kind="[object Object]"
               type="button"
             >
@@ -16391,7 +16401,7 @@ exports[`DataTable should paginate 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -16406,13 +16416,13 @@ exports[`DataTable should paginate 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c21"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -16466,7 +16476,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   stroke: none;
 }
 
-.c21 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -16477,25 +16487,25 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   stroke: #000000;
 }
 
-.c21 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c21 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c21 *[stroke*="#"],
-.c21 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c21 *[fill-rule],
-.c21 *[FILL-RULE],
-.c21 *[fill*="#"],
-.c21 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -16754,7 +16764,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border: 0;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -16786,31 +16796,31 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   flex: 1 0 auto;
 }
 
-.c20 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c20:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -16861,7 +16871,12 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border-radius: 4px;
 }
 
-.c16:hover {
+.c20 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c20:hover {
   padding: 4px;
 }
 
@@ -17447,7 +17462,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c19 c16"
+              class="c19 c20"
               kind="[object Object]"
               type="button"
             >
@@ -17462,7 +17477,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -17477,7 +17492,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 3"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -17492,7 +17507,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 4"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -17507,7 +17522,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 5"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -17522,7 +17537,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 6"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -17537,7 +17552,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 7"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -17552,13 +17567,13 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c21"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -17612,7 +17627,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   stroke: none;
 }
 
-.c21 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -17623,25 +17638,25 @@ exports[`DataTable should render new data when page changes 1`] = `
   stroke: #000000;
 }
 
-.c21 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c21 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c21 *[stroke*="#"],
-.c21 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c21 *[fill-rule],
-.c21 *[FILL-RULE],
-.c21 *[fill*="#"],
-.c21 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -17900,7 +17915,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   border: 0;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -17932,31 +17947,31 @@ exports[`DataTable should render new data when page changes 1`] = `
   flex: 1 0 auto;
 }
 
-.c20 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c20:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -18007,7 +18022,12 @@ exports[`DataTable should render new data when page changes 1`] = `
   border-radius: 4px;
 }
 
-.c16:hover {
+.c20 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c20:hover {
   padding: 4px;
 }
 
@@ -19709,7 +19729,7 @@ exports[`DataTable should render new data when page changes 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c19 c16"
+              class="c19 c20"
               kind="[object Object]"
               type="button"
             >
@@ -19724,7 +19744,7 @@ exports[`DataTable should render new data when page changes 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -19739,13 +19759,13 @@ exports[`DataTable should render new data when page changes 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c21"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -23610,7 +23630,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
               kind="[object Object]"
               type="button"
             >
@@ -23637,7 +23657,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+              class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
               kind="[object Object]"
               type="button"
             >
@@ -23653,7 +23673,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+              class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
               kind="[object Object]"
               type="button"
             >
@@ -23669,7 +23689,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 fVgacz StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+              class="StyledButtonKind-sc-1vhfpnt-0 fVgacz StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 dwBFBp"
               disabled=""
               kind="[object Object]"
               type="button"
@@ -23730,7 +23750,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   stroke: none;
 }
 
-.c21 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -23741,25 +23761,25 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   stroke: #000000;
 }
 
-.c21 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c21 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c21 *[stroke*="#"],
-.c21 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c21 *[fill-rule],
-.c21 *[FILL-RULE],
-.c21 *[fill*="#"],
-.c21 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -24018,7 +24038,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border: 0;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -24050,31 +24070,31 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   flex: 1 0 auto;
 }
 
-.c20 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c20:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -24125,7 +24145,12 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border-radius: 4px;
 }
 
-.c16:hover {
+.c20 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c20:hover {
   padding: 4px;
 }
 
@@ -25827,7 +25852,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c19 c16"
+              class="c19 c20"
               kind="[object Object]"
               type="button"
             >
@@ -25842,7 +25867,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
           >
             <button
               aria-label="Go to page 2"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
@@ -25857,13 +25882,13 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
           >
             <button
               aria-label="Go to next page"
-              class="c20 c16"
+              class="c21 c20"
               kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c21"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -25917,7 +25942,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   stroke: none;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -25928,25 +25953,25 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   stroke: #666666;
 }
 
-.c20 g {
+.c21 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c20 *:not([stroke])[fill="none"] {
+.c21 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c20 *[stroke*="#"],
-.c20 *[STROKE*="#"] {
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c20 *[fill-rule],
-.c20 *[FILL-RULE],
-.c20 *[fill*="#"],
-.c20 *[FILL*="#"] {
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -26296,6 +26321,11 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 
 .c15:hover {
   padding: 4px;
+}
+
+.c20 {
+  padding: 4px;
+  border-radius: 4px;
 }
 
 .c13 {
@@ -27859,14 +27889,14 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="c19 c15"
+              class="c19 c20"
               disabled=""
               kind="[object Object]"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c20"
+                class="c21"
                 viewBox="0 0 24 24"
               >
                 <polyline

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -2136,7 +2136,7 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: none;
 }
 
-.c17 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -2147,25 +2147,25 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: #000000;
 }
 
-.c17 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*="#"],
-.c17 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*="#"],
-.c17 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -2309,7 +2309,7 @@ exports[`List events should apply pagination styling 1`] = `
   width: 3px;
 }
 
-.c16 {
+.c17 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -2435,7 +2435,7 @@ exports[`List events should apply pagination styling 1`] = `
   border: 0;
 }
 
-.c15 {
+.c16 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2467,31 +2467,31 @@ exports[`List events should apply pagination styling 1`] = `
   flex: 1 0 auto;
 }
 
-.c15 > svg {
+.c16 > svg {
   vertical-align: bottom;
 }
 
-.c15:hover {
+.c16:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c15:focus {
+.c16:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus > circle,
-.c15:focus > ellipse,
-.c15:focus > line,
-.c15:focus > path,
-.c15:focus > polygon,
-.c15:focus > polyline,
-.c15:focus > rect {
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus::-moz-focus-inner {
+.c16:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -2500,7 +2500,12 @@ exports[`List events should apply pagination styling 1`] = `
   border-radius: 4px;
 }
 
-.c11:hover {
+.c15 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c15:hover {
   padding: 4px;
 }
 
@@ -2706,7 +2711,7 @@ exports[`List events should apply pagination styling 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c14 c11"
+            class="c14 c15"
             kind="[object Object]"
             type="button"
           >
@@ -2721,7 +2726,7 @@ exports[`List events should apply pagination styling 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -2736,7 +2741,7 @@ exports[`List events should apply pagination styling 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -2751,7 +2756,7 @@ exports[`List events should apply pagination styling 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -2766,7 +2771,7 @@ exports[`List events should apply pagination styling 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -2780,7 +2785,7 @@ exports[`List events should apply pagination styling 1`] = `
           class="c9"
         >
           <span
-            class="c16"
+            class="c17"
           >
             …
           </span>
@@ -2793,7 +2798,7 @@ exports[`List events should apply pagination styling 1`] = `
         >
           <button
             aria-label="Go to page 10"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -2808,13 +2813,13 @@ exports[`List events should apply pagination styling 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c17"
+              class="c18"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -2833,6 +2838,734 @@ exports[`List events should apply pagination styling 1`] = `
 `;
 
 exports[`List events should paginate 1`] = `
+.c12 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c18 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c18 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c18 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 0px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c13 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c17 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c10 > svg {
+  vertical-align: bottom;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c14 > svg {
+  vertical-align: bottom;
+}
+
+.c14:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus > circle,
+.c14:focus > ellipse,
+.c14:focus > line,
+.c14:focus > path,
+.c14:focus > polygon,
+.c14:focus > polyline,
+.c14:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c16 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c16 > svg {
+  vertical-align: bottom;
+}
+
+.c16:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c16:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c15 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c15:hover {
+  padding: 4px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 32px;
+  max-width: 100%;
+  min-width: 32px;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c13 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <ul
+    class="c1"
+  >
+    <li
+      class="c2 c3"
+    >
+      entry-0
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-1
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-2
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-3
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-4
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-5
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-6
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-7
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-8
+    </li>
+    <li
+      class="c4 c3"
+    >
+      entry-9
+    </li>
+    <li
+      class="c5"
+    >
+      <div
+        class="c6"
+      />
+    </li>
+  </ul>
+  <div
+    class="c7 Pagination__StyledPaginationContainer-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c5"
+    >
+      <ul
+        class="c8"
+      >
+        <li
+          class="c9"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c10 c11"
+            disabled=""
+            kind="[object Object]"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <polyline
+                fill="none"
+                points="7 2 17 12 7 22"
+                stroke="#000"
+                stroke-width="2"
+                transform="matrix(-1 0 0 1 24 0)"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c14 c15"
+            kind="[object Object]"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c16 c15"
+            kind="[object Object]"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c16 c15"
+            kind="[object Object]"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c16 c15"
+            kind="[object Object]"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c16 c15"
+            kind="[object Object]"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <span
+            class="c17"
+          >
+            …
+          </span>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <button
+            aria-label="Go to page 10"
+            class="c16 c15"
+            kind="[object Object]"
+            type="button"
+          >
+            10
+          </button>
+        </li>
+        <div
+          class="c13"
+        />
+        <li
+          class="c9"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c16 c15"
+            kind="[object Object]"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c18"
+              viewBox="0 0 24 24"
+            >
+              <polyline
+                fill="none"
+                points="7 2 17 12 7 22"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`List events should render correct num items per page (step) 1`] = `
 .c12 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -3038,12 +3771,6 @@ exports[`List events should paginate 1`] = `
   width: 3px;
 }
 
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
 .c10 {
   display: inline-block;
   box-sizing: border-box;
@@ -3164,725 +3891,8 @@ exports[`List events should paginate 1`] = `
   border: 0;
 }
 
-.c15 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c15 > svg {
-  vertical-align: bottom;
-}
-
-.c15:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c15:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c15:focus > circle,
-.c15:focus > ellipse,
-.c15:focus > line,
-.c15:focus > path,
-.c15:focus > polygon,
-.c15:focus > polyline,
-.c15:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c15:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  padding: 4px;
-  border-radius: 4px;
-}
-
-.c11:hover {
-  padding: 4px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 32px;
-  max-width: 100%;
-  min-width: 32px;
-}
-
-.c1 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    border-top: solid 1px rgba(0,0,0,0.33);
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c13 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <ul
-    class="c1"
-  >
-    <li
-      class="c2 c3"
-    >
-      entry-0
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-1
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-2
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-3
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-4
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-5
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-6
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-7
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-8
-    </li>
-    <li
-      class="c4 c3"
-    >
-      entry-9
-    </li>
-    <li
-      class="c5"
-    >
-      <div
-        class="c6"
-      />
-    </li>
-  </ul>
-  <div
-    class="c7 Pagination__StyledPaginationContainer-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c5"
-    >
-      <ul
-        class="c8"
-      >
-        <li
-          class="c9"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c10 c11"
-            disabled=""
-            kind="[object Object]"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c12"
-              viewBox="0 0 24 24"
-            >
-              <polyline
-                fill="none"
-                points="7 2 17 12 7 22"
-                stroke="#000"
-                stroke-width="2"
-                transform="matrix(-1 0 0 1 24 0)"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c14 c11"
-            kind="[object Object]"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c15 c11"
-            kind="[object Object]"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c15 c11"
-            kind="[object Object]"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c15 c11"
-            kind="[object Object]"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c15 c11"
-            kind="[object Object]"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <span
-            class="c16"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <button
-            aria-label="Go to page 10"
-            class="c15 c11"
-            kind="[object Object]"
-            type="button"
-          >
-            10
-          </button>
-        </li>
-        <div
-          class="c13"
-        />
-        <li
-          class="c9"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c15 c11"
-            kind="[object Object]"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c17"
-              viewBox="0 0 24 24"
-            >
-              <polyline
-                fill="none"
-                points="7 2 17 12 7 22"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`List events should render correct num items per page (step) 1`] = `
-.c12 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c12 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c12 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c12 *[stroke*="#"],
-.c12 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*="#"],
-.c12 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
 .c16 {
   display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c16 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c16 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c16 *[stroke*="#"],
-.c16 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c16 *[fill-rule],
-.c16 *[FILL-RULE],
-.c16 *[fill*="#"],
-.c16 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-top: solid 1px rgba(0,0,0,0.33);
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 0px;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-self: flex-end;
-  -ms-flex-item-align: end;
-  align-self: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c13 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10 > svg {
-  vertical-align: bottom;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c14 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-  border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51,51,51,0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c14 > svg {
-  vertical-align: bottom;
-}
-
-.c14:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c14:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c14:focus > circle,
-.c14:focus > ellipse,
-.c14:focus > line,
-.c14:focus > path,
-.c14:focus > polygon,
-.c14:focus > polyline,
-.c14:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c14:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c15 {
-  display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
   font: inherit;
@@ -3913,31 +3923,31 @@ exports[`List events should render correct num items per page (step) 1`] = `
   flex: 1 0 auto;
 }
 
-.c15 > svg {
+.c16 > svg {
   vertical-align: bottom;
 }
 
-.c15:hover {
+.c16:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c15:focus {
+.c16:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus > circle,
-.c15:focus > ellipse,
-.c15:focus > line,
-.c15:focus > path,
-.c15:focus > polygon,
-.c15:focus > polyline,
-.c15:focus > rect {
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus::-moz-focus-inner {
+.c16:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -3946,7 +3956,12 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border-radius: 4px;
 }
 
-.c11:hover {
+.c15 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c15:hover {
   padding: 4px;
 }
 
@@ -4166,7 +4181,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c14 c11"
+            class="c14 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4181,7 +4196,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4196,7 +4211,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4211,7 +4226,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4226,7 +4241,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4241,7 +4256,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
         >
           <button
             aria-label="Go to page 6"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4256,7 +4271,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
         >
           <button
             aria-label="Go to page 7"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4271,13 +4286,13 @@ exports[`List events should render correct num items per page (step) 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c16"
+              class="c17"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -4330,7 +4345,7 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: none;
 }
 
-.c17 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4341,25 +4356,25 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: #000000;
 }
 
-.c17 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*="#"],
-.c17 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*="#"],
-.c17 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4501,7 +4516,7 @@ exports[`List events should render new data when page changes 1`] = `
   width: 3px;
 }
 
-.c16 {
+.c17 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -4627,7 +4642,7 @@ exports[`List events should render new data when page changes 1`] = `
   border: 0;
 }
 
-.c15 {
+.c16 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4659,31 +4674,31 @@ exports[`List events should render new data when page changes 1`] = `
   flex: 1 0 auto;
 }
 
-.c15 > svg {
+.c16 > svg {
   vertical-align: bottom;
 }
 
-.c15:hover {
+.c16:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c15:focus {
+.c16:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus > circle,
-.c15:focus > ellipse,
-.c15:focus > line,
-.c15:focus > path,
-.c15:focus > polygon,
-.c15:focus > polyline,
-.c15:focus > rect {
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus::-moz-focus-inner {
+.c16:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -4692,7 +4707,12 @@ exports[`List events should render new data when page changes 1`] = `
   border-radius: 4px;
 }
 
-.c11:hover {
+.c15 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c15:hover {
   padding: 4px;
 }
 
@@ -4892,7 +4912,7 @@ exports[`List events should render new data when page changes 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c14 c11"
+            class="c14 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4907,7 +4927,7 @@ exports[`List events should render new data when page changes 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4922,7 +4942,7 @@ exports[`List events should render new data when page changes 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4937,7 +4957,7 @@ exports[`List events should render new data when page changes 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4952,7 +4972,7 @@ exports[`List events should render new data when page changes 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4966,7 +4986,7 @@ exports[`List events should render new data when page changes 1`] = `
           class="c9"
         >
           <span
-            class="c16"
+            class="c17"
           >
             …
           </span>
@@ -4979,7 +4999,7 @@ exports[`List events should render new data when page changes 1`] = `
         >
           <button
             aria-label="Go to page 10"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
@@ -4994,13 +5014,13 @@ exports[`List events should render new data when page changes 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c15 c11"
+            class="c16 c15"
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c17"
+              class="c18"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -5098,7 +5118,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -5125,7 +5145,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -5141,7 +5161,7 @@ exports[`List events should render new data when page changes 2`] = `
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -5156,7 +5176,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -5171,7 +5191,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -5186,7 +5206,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -5213,7 +5233,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 10"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -5228,7 +5248,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -2500,6 +2500,10 @@ exports[`List events should apply pagination styling 1`] = `
   border-radius: 4px;
 }
 
+.c11:hover {
+  padding: 4px;
+}
+
 .c9 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3225,6 +3229,10 @@ exports[`List events should paginate 1`] = `
   border-radius: 4px;
 }
 
+.c11:hover {
+  padding: 4px;
+}
+
 .c9 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3936,6 +3944,10 @@ exports[`List events should render correct num items per page (step) 1`] = `
 .c11 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c11:hover {
+  padding: 4px;
 }
 
 .c9 {
@@ -4680,6 +4692,10 @@ exports[`List events should render new data when page changes 1`] = `
   border-radius: 4px;
 }
 
+.c11:hover {
+  padding: 4px;
+}
+
 .c9 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -5082,7 +5098,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5109,7 +5125,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5125,7 +5141,7 @@ exports[`List events should render new data when page changes 2`] = `
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5140,7 +5156,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5155,7 +5171,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5170,7 +5186,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5197,7 +5213,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to page 10"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5212,7 +5228,7 @@ exports[`List events should render new data when page changes 2`] = `
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5540,6 +5556,10 @@ exports[`List events should show correct item index when "show" is a number 1`] 
 .c11 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c11:hover {
+  padding: 4px;
 }
 
 .c9 {
@@ -6166,6 +6186,10 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 .c11 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c11:hover {
+  padding: 4px;
 }
 
 .c9 {

--- a/src/js/components/Pagination/StyledPageControl.js
+++ b/src/js/components/Pagination/StyledPageControl.js
@@ -2,6 +2,43 @@ import styled from 'styled-components';
 
 import { Button } from '../Button';
 
+const BUTTON_STATES = ['default', 'active', 'disabled', 'hover', 'selected'];
+const defaultStyles = {
+  border: {
+    radius: '4px',
+  },
+  pad: '4px',
+};
+
+// Assemble button theme object for each button state
+const buildButtonStyle = (buttonTheme, kind) => {
+  const style = buttonTheme[kind];
+  BUTTON_STATES.forEach(state => {
+    if (state !== 'default') style[state] = buttonTheme[state][kind];
+  });
+  return style;
+};
+
+// Allow padding to flex when border is present. Calculated adjusted
+// padding needed (if any) for each button state.
+const calcAdjustedPadding = (buttonStyle, pad) => {
+  const adjustedPadding = {};
+
+  BUTTON_STATES.forEach(state => {
+    const border =
+      (buttonStyle[state] &&
+        buttonStyle[state].border &&
+        buttonStyle[state].border.width) ||
+      (buttonStyle.border && buttonStyle.border.width) ||
+      '0px';
+
+    const adjustedPad = `${pad.replace('px', '') - border.replace('px', '')}px`;
+    adjustedPadding[state] = { pad: undefined };
+    adjustedPadding[state].pad = adjustedPad;
+  });
+  return adjustedPadding;
+};
+
 // sizeStyle is exploratory, but would allow user to apply a size
 // prop to their Pagination component which would scale everything
 // up or down. This does not necessarily have to be part of the first pass,
@@ -30,8 +67,30 @@ const sizeStyle = props => {
 };
 
 export const StyledPaginationButton = styled(Button)`
-  padding: 4px;
-  border-radius: 4px;
+  ${props => {
+    const buttonStyle =
+      typeof props.kind === 'string'
+        ? buildButtonStyle(props.theme.button, props.kind)
+        : props.kind;
+    const adjustedPadding = calcAdjustedPadding(buttonStyle, defaultStyles.pad);
+    let buttonState = 'default';
+    if (props.active) buttonState = 'active';
+    else if (props.selected) buttonState = 'selected';
+    else if (props.disabled) buttonState = 'disabled';
+
+    return `
+      padding: ${adjustedPadding[buttonState].pad};
+      :hover {
+        padding: ${
+          buttonState === 'disabled'
+            ? adjustedPadding[buttonState].pad
+            : adjustedPadding.hover.pad
+        };
+      }
+    `;
+  }}
+  
+  border-radius: ${defaultStyles.border.radius};
   ${props => sizeStyle(props).content};
 `;
 

--- a/src/js/components/Pagination/StyledPageControl.js
+++ b/src/js/components/Pagination/StyledPageControl.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Button } from '../Button';
 
-const BUTTON_STATES = ['default', 'active', 'disabled', 'hover', 'selected'];
+const BUTTON_STATES = ['normal', 'active', 'disabled', 'hover'];
 const defaultStyles = {
   border: {
     radius: '4px',
@@ -14,7 +14,7 @@ const defaultStyles = {
 const buildButtonStyle = (buttonTheme, kind) => {
   const style = buttonTheme[kind];
   BUTTON_STATES.forEach(state => {
-    if (state !== 'default') style[state] = buttonTheme[state][kind];
+    if (state !== 'normal') style[state] = buttonTheme[state][kind];
   });
   return style;
 };
@@ -73,19 +73,16 @@ export const StyledPaginationButton = styled(Button)`
         ? buildButtonStyle(props.theme.button, props.kind)
         : props.kind;
     const adjustedPadding = calcAdjustedPadding(buttonStyle, defaultStyles.pad);
-    let buttonState = 'default';
+    let buttonState = 'normal';
     if (props.active) buttonState = 'active';
-    else if (props.selected) buttonState = 'selected';
     else if (props.disabled) buttonState = 'disabled';
 
     return `
       padding: ${adjustedPadding[buttonState].pad};
-      :hover {
-        padding: ${
-          buttonState === 'disabled'
-            ? adjustedPadding[buttonState].pad
-            : adjustedPadding.hover.pad
-        };
+      ${
+        buttonState === 'disabled'
+          ? ''
+          : `:hover { padding: ${adjustedPadding.hover.pad}; }`
       }
     `;
   }}

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -488,7 +488,7 @@ exports[`Pagination should apply custom theme 1`] = `
   stroke: none;
 }
 
-.c13 {
+.c14 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -499,25 +499,25 @@ exports[`Pagination should apply custom theme 1`] = `
   stroke: #000000;
 }
 
-.c13 g {
+.c14 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill="none"] {
+.c14 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*="#"],
-.c13 *[STROKE*="#"] {
+.c14 *[stroke*="#"],
+.c14 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*="#"],
-.c13 *[FILL*="#"] {
+.c14 *[fill-rule],
+.c14 *[FILL-RULE],
+.c14 *[fill*="#"],
+.c14 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -593,7 +593,7 @@ exports[`Pagination should apply custom theme 1`] = `
   width: 3px;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -719,7 +719,7 @@ exports[`Pagination should apply custom theme 1`] = `
   border: 0;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -751,31 +751,31 @@ exports[`Pagination should apply custom theme 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 > svg {
+.c12 > svg {
   vertical-align: bottom;
 }
 
-.c11:hover {
+.c12:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c11:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -784,7 +784,12 @@ exports[`Pagination should apply custom theme 1`] = `
   border-radius: 4px;
 }
 
-.c7:hover {
+.c11 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c11:hover {
   padding: 4px;
 }
 
@@ -876,7 +881,7 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c10 c7"
+            class="c10 c11"
             kind="[object Object]"
             type="button"
           >
@@ -891,7 +896,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c7"
+            class="c12 c11"
             kind="[object Object]"
             type="button"
           >
@@ -906,7 +911,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c7"
+            class="c12 c11"
             kind="[object Object]"
             type="button"
           >
@@ -921,7 +926,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c11 c7"
+            class="c12 c11"
             kind="[object Object]"
             type="button"
           >
@@ -936,7 +941,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c11 c7"
+            class="c12 c11"
             kind="[object Object]"
             type="button"
           >
@@ -950,7 +955,7 @@ exports[`Pagination should apply custom theme 1`] = `
           class="c5"
         >
           <span
-            class="c12"
+            class="c13"
           >
             …
           </span>
@@ -963,7 +968,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c7"
+            class="c12 c11"
             kind="[object Object]"
             type="button"
           >
@@ -978,13 +983,13 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c11 c7"
+            class="c12 c11"
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c14"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -1037,7 +1042,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   stroke: none;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1048,25 +1053,25 @@ exports[`Pagination should disable next button if on last page 1`] = `
   stroke: #666666;
 }
 
-.c12 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*="#"],
-.c12 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*="#"],
-.c12 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1337,6 +1342,11 @@ exports[`Pagination should disable next button if on last page 1`] = `
   padding: 4px;
 }
 
+.c12 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1522,14 +1532,14 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-disabled="true"
             aria-label="Go to next page"
-            class="c11 c6"
+            class="c11 c12"
             disabled=""
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -1779,7 +1789,12 @@ exports[`Pagination should disable previous and next controls when numItems
   border-radius: 4px;
 }
 
-.c6:hover {
+.c10 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c10:hover {
   padding: 4px;
 }
 
@@ -1867,7 +1882,7 @@ exports[`Pagination should disable previous and next controls when numItems
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c9 c10"
             kind="[object Object]"
             type="button"
           >
@@ -2075,10 +2090,6 @@ exports[`Pagination should disable previous and next controls when numItems
 .c6 {
   padding: 4px;
   border-radius: 4px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c4 {
@@ -2421,7 +2432,12 @@ exports[`Pagination should disable previous and next controls when numItems
   border-radius: 4px;
 }
 
-.c6:hover {
+.c10 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c10:hover {
   padding: 4px;
 }
 
@@ -2509,7 +2525,7 @@ exports[`Pagination should disable previous and next controls when numItems
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c9 c10"
             kind="[object Object]"
             type="button"
           >
@@ -2585,7 +2601,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   stroke: none;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -2596,25 +2612,25 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   stroke: #000000;
 }
 
-.c12 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*="#"],
-.c12 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*="#"],
-.c12 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -2690,7 +2706,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   width: 3px;
 }
 
-.c11 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -2816,7 +2832,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   border: 0;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2848,31 +2864,31 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   flex: 1 0 auto;
 }
 
-.c10 > svg {
+.c11 > svg {
   vertical-align: bottom;
 }
 
-.c10:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c10:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -2881,7 +2897,12 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   border-radius: 4px;
 }
 
-.c6:hover {
+.c10 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c10:hover {
   padding: 4px;
 }
 
@@ -2969,7 +2990,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c9 c10"
             kind="[object Object]"
             type="button"
           >
@@ -2984,7 +3005,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -2999,7 +3020,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -3014,7 +3035,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -3029,7 +3050,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -3043,7 +3064,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           class="c4"
         >
           <span
-            class="c11"
+            class="c12"
           >
             …
           </span>
@@ -3056,7 +3077,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -3071,13 +3092,13 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -3568,7 +3589,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -3595,7 +3616,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -3611,7 +3632,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -3626,7 +3647,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -3641,7 +3662,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -3656,7 +3677,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -3683,7 +3704,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -3698,7 +3719,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4648,7 +4669,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4675,7 +4696,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4691,7 +4712,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4706,7 +4727,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4721,7 +4742,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4736,7 +4757,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4763,7 +4784,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4778,7 +4799,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jvstun"
             kind="[object Object]"
             type="button"
           >
@@ -4838,7 +4859,7 @@ exports[`Pagination should display the correct last page based on items length
   stroke: none;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4849,25 +4870,25 @@ exports[`Pagination should display the correct last page based on items length
   stroke: #000000;
 }
 
-.c12 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*="#"],
-.c12 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*="#"],
-.c12 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4943,7 +4964,7 @@ exports[`Pagination should display the correct last page based on items length
   width: 3px;
 }
 
-.c11 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -5069,7 +5090,7 @@ exports[`Pagination should display the correct last page based on items length
   border: 0;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5101,31 +5122,31 @@ exports[`Pagination should display the correct last page based on items length
   flex: 1 0 auto;
 }
 
-.c10 > svg {
+.c11 > svg {
   vertical-align: bottom;
 }
 
-.c10:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c10:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -5134,7 +5155,12 @@ exports[`Pagination should display the correct last page based on items length
   border-radius: 4px;
 }
 
-.c6:hover {
+.c10 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c10:hover {
   padding: 4px;
 }
 
@@ -5222,7 +5248,7 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c9 c10"
             kind="[object Object]"
             type="button"
           >
@@ -5237,7 +5263,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -5252,7 +5278,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -5267,7 +5293,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 4"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -5282,7 +5308,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 5"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -5296,7 +5322,7 @@ exports[`Pagination should display the correct last page based on items length
           class="c4"
         >
           <span
-            class="c11"
+            class="c12"
           >
             …
           </span>
@@ -5309,7 +5335,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -5324,13 +5350,13 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to next page"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -6835,7 +6861,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   stroke: none;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6846,25 +6872,25 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   stroke: #000000;
 }
 
-.c12 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*="#"],
-.c12 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*="#"],
-.c12 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6940,7 +6966,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   width: 3px;
 }
 
-.c11 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -7066,7 +7092,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   border: 0;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7098,31 +7124,31 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   flex: 1 0 auto;
 }
 
-.c10 > svg {
+.c11 > svg {
   vertical-align: bottom;
 }
 
-.c10:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c10:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -7131,7 +7157,12 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   border-radius: 4px;
 }
 
-.c6:hover {
+.c10 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c10:hover {
   padding: 4px;
 }
 
@@ -7219,7 +7250,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c9 c10"
             kind="[object Object]"
             type="button"
           >
@@ -7234,7 +7265,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -7249,7 +7280,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -7263,7 +7294,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
           class="c4"
         >
           <span
-            class="c11"
+            class="c12"
           >
             …
           </span>
@@ -7276,7 +7307,7 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
@@ -7291,13 +7322,13 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
         >
           <button
             aria-label="Go to next page"
-            class="c10 c6"
+            class="c11 c10"
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -7351,7 +7382,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   stroke: none;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7362,25 +7393,25 @@ exports[`Pagination should set page to last page if page prop > total possible
   stroke: #666666;
 }
 
-.c12 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*="#"],
-.c12 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*="#"],
-.c12 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7651,6 +7682,11 @@ exports[`Pagination should set page to last page if page prop > total possible
   padding: 4px;
 }
 
+.c12 {
+  padding: 4px;
+  border-radius: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -7836,14 +7872,14 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-disabled="true"
             aria-label="Go to next page"
-            class="c11 c6"
+            class="c11 c12"
             disabled=""
             kind="[object Object]"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c12"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -241,6 +241,10 @@ exports[`Pagination should allow user to control page via state with page +
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -778,6 +782,10 @@ exports[`Pagination should apply custom theme 1`] = `
 .c7 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c7:hover {
+  padding: 4px;
 }
 
 .c5 {
@@ -1325,6 +1333,10 @@ exports[`Pagination should disable next button if on last page 1`] = `
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1767,6 +1779,10 @@ exports[`Pagination should disable previous and next controls when numItems
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2059,6 +2075,10 @@ exports[`Pagination should disable previous and next controls when numItems
 .c6 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c6:hover {
+  padding: 4px;
 }
 
 .c4 {
@@ -2399,6 +2419,10 @@ exports[`Pagination should disable previous and next controls when numItems
 .c6 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c6:hover {
+  padding: 4px;
 }
 
 .c4 {
@@ -2857,6 +2881,10 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3308,6 +3336,10 @@ exports[`Pagination should display next page of results when "next" is
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3536,7 +3568,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3563,7 +3595,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3579,7 +3611,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3594,7 +3626,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3609,7 +3641,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3624,7 +3656,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3651,7 +3683,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3666,7 +3698,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -3931,6 +3963,10 @@ exports[`Pagination should display page 'n' of results when "page n" is
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4380,6 +4416,10 @@ exports[`Pagination should display previous page of results when "previous" is
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4608,7 +4648,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -4635,7 +4675,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -4651,7 +4691,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 jrRdnJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -4666,7 +4706,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -4681,7 +4721,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -4696,7 +4736,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -4723,7 +4763,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -4738,7 +4778,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 khwAB"
+            class="StyledButtonKind-sc-1vhfpnt-0 cWvYKj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 hIPATj"
             kind="[object Object]"
             type="button"
           >
@@ -5092,6 +5132,10 @@ exports[`Pagination should display the correct last page based on items length
 .c6 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c6:hover {
+  padding: 4px;
 }
 
 .c4 {
@@ -5542,6 +5586,10 @@ exports[`Pagination should render correct numEdgePages 1`] = `
 .c6 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c6:hover {
+  padding: 4px;
 }
 
 .c4 {
@@ -6049,6 +6097,10 @@ exports[`Pagination should render correct numMiddlePages when even 1`] = `
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -6507,6 +6559,10 @@ exports[`Pagination should render correct numMiddlePages when odd 1`] = `
 .c6 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c6:hover {
+  padding: 4px;
 }
 
 .c4 {
@@ -7075,6 +7131,10 @@ exports[`Pagination should set numMiddlePages = 1 if user provides value < 1 1`]
   border-radius: 4px;
 }
 
+.c6:hover {
+  padding: 4px;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -7585,6 +7645,10 @@ exports[`Pagination should set page to last page if page prop > total possible
 .c6 {
   padding: 4px;
   border-radius: 4px;
+}
+
+.c6:hover {
+  padding: 4px;
 }
 
 .c4 {

--- a/src/js/components/Pagination/stories/Custom.js
+++ b/src/js/components/Pagination/stories/Custom.js
@@ -34,22 +34,58 @@ const customTheme = deepMerge(grommet, {
   },
 });
 
-const secondTheme = deepMerge(hpe, {
+const secondaryTheme = deepMerge(hpe, {
   pagination: {
     button: 'secondary',
   },
 });
 
+const primaryTheme = deepMerge(hpe, {
+  pagination: {
+    button: 'primary',
+  },
+});
+
 export const Custom = () => (
   <Grommet theme={customTheme}>
-    <Box align="start" pad="small" gap="small">
-      <Text>Custom Theme</Text>
-      <Pagination numItems={237} />
-
-      <Text>Reference Button Kind secondary by string with HPE theme</Text>
-      <ThemeContext.Extend value={secondTheme}>
+    <Box direction="row">
+      <Box
+        align="start"
+        pad={{ top: 'small', bottom: 'medium', horizontal: 'medium' }}
+        gap="small"
+      >
+        <Text>Custom Theme</Text>
         <Pagination numItems={237} />
-      </ThemeContext.Extend>
+
+        <Text>Reference Button Kind secondary by string with HPE theme</Text>
+        <ThemeContext.Extend value={secondaryTheme}>
+          <Pagination numItems={237} />
+        </ThemeContext.Extend>
+
+        <Text>Reference Button Kind primary by string with HPE theme</Text>
+        <ThemeContext.Extend value={primaryTheme}>
+          <Pagination numItems={237} />
+        </ThemeContext.Extend>
+      </Box>
+      <Box
+        align="start"
+        background="black"
+        pad={{ top: 'small', bottom: 'medium', horizontal: 'medium' }}
+        gap="small"
+      >
+        <Text>Custom Theme</Text>
+        <Pagination numItems={237} />
+
+        <Text>Reference Button Kind secondary by string with HPE theme</Text>
+        <ThemeContext.Extend value={secondaryTheme}>
+          <Pagination numItems={237} />
+        </ThemeContext.Extend>
+
+        <Text>Reference Button Kind primary by string with HPE theme</Text>
+        <ThemeContext.Extend value={primaryTheme}>
+          <Pagination numItems={237} />
+        </ThemeContext.Extend>
+      </Box>
     </Box>
   </Grommet>
 );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
To maintain consistent control sizes across button states, this work allows padding to flex based off of button border width styles for each state.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
