### PR TITLE
adding pagination themeDocs definitions

### DIFF
--- a/src/js/components/Pagination/README.md
+++ b/src/js/components/Pagination/README.md
@@ -219,7 +219,7 @@ text-strong
 
 **pagination.button.hover.background.color**
 
-Background color when the button when hovered. Expects `string | { dark: string, light: string }`.
+Background color of the button when hovered. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
@@ -239,8 +239,8 @@ undefined
 
 **pagination.container**
 
-Any valid Box property affecting the Box 
-    wrapping the pagination controls. Expects `object`.
+Any valid Box props for the Box wrapping the 
+    pagination controls. Expects `object`.
 
 Defaults to
 
@@ -261,7 +261,7 @@ undefined
 
 **pagination.control.extend**
 
-Any additional style for each pagination control. Expects `string | (props) => {}`.
+Any additional style for each control. Expects `string | (props) => {}`.
 
 Defaults to
 
@@ -271,7 +271,7 @@ undefined
 
 **pagination.control.pad**
 
-Padding around each pagination control's label. Expects `string | object`.
+Padding around each control's label. Expects `string | object`.
 
 Defaults to
 
@@ -321,7 +321,7 @@ Defaults to
 
 **pagination.control.size.small.height**
 
-The height for each pagination control. Expects `string`.
+The height for each control. Expects `string`.
 
 Defaults to
 
@@ -331,7 +331,7 @@ Defaults to
 
 **pagination.control.size.small.width**
 
-The minimum width for each pagination control. 
+The minimum width for each control. 
     Width will scale up fitting the control's label. Expects `string`.
 
 Defaults to
@@ -382,7 +382,7 @@ Defaults to
 
 **pagination.control.size.medium.height**
 
-The height for each pagination control. Expects `string`.
+The height for each control. Expects `string`.
 
 Defaults to
 
@@ -392,7 +392,7 @@ Defaults to
 
 **pagination.control.size.medium.width**
 
-The minimum width for each pagination control. 
+The minimum width for each control. 
     Width will scale up fitting the control's label. Expects `string`.
 
 Defaults to
@@ -443,7 +443,7 @@ Defaults to
 
 **pagination.control.size.large.height**
 
-The height for each pagination control. Expects `string`.
+The height for each control. Expects `string`.
 
 Defaults to
 
@@ -453,7 +453,7 @@ Defaults to
 
 **pagination.control.size.large.width**
 
-The minimum width for each pagination control. 
+The minimum width for each control. 
     Width will scale up fitting the control's label. Expects `string`.
 
 Defaults to
@@ -516,7 +516,7 @@ none
 
 **pagination.icons.color**
 
-Color to fill the controls' icons. Expects `string | { dark: string, light: string }`.
+The color used for the icon. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 

--- a/src/js/components/Pagination/README.md
+++ b/src/js/components/Pagination/README.md
@@ -127,7 +127,7 @@ string
 
 **numberEdgePages**
 
-The number of page buttons visible at the start and end of page 
+The number of pagination buttons visible at the start and end of page 
         range. Defaults to `1`.
 
 ```
@@ -136,7 +136,7 @@ number
 
 **numberItems**
 
-The number of items to paginate.
+The total number of items to paginate.
 
 ```
 number
@@ -144,7 +144,8 @@ number
 
 **numberMiddlePages**
 
-The number of page buttons visible in the middle of the controls. Defaults to `3`.
+The number of pagination buttons visible in the middle of the 
+        controls. Defaults to `3`.
 
 ```
 number
@@ -152,10 +153,10 @@ number
 
 **onChange**
 
-Function that will be called when the user clicks a page or 
-        arrow button. The single argument is an event containing the latest 
-        page via `event.page`, and the startIndex and endIndex for data on 
-        this page via `event.startIndex` and `event.endIndex`, 
+Function called when the user clicks a page or arrow button. The 
+        single argument is an event containing the target page via 
+        `event.page`, and the startIndex and endIndex for items contained 
+        in the target page via `event.startIndex` and `event.endIndex`, 
         respectively.
 
 ```
@@ -196,46 +197,39 @@ nav
 ```
 ## Theme
   
-**pagination**
+**pagination.button.active.background.color**
 
-The possible sizes of the Pagination in terms of its 
-      max-width, font-size and line-height. Expects `object`.
+Background color when the button is active. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
 ```
-{
-      small: {
-        size: '14px',
-        height: '20px',
-        maxWidth: '336px',
-       },
-      medium: {
-        size: '18px',
-        height: '24px',
-        maxWidth: '432px',
-      },
-      large: {
-        size: '22px',
-        height: '28px',
-        maxWidth: '528px',
-      },
-      xlarge: {
-        size: '26px',
-        height: '32px',
-        maxWidth: '624px',
-      },
-      xxlarge: {
-        size: '34px',
-        height: '40px',
-        maxWidth: '816px',
-      },
-    }
+active-background
 ```
 
-**pagination.extend**
+**pagination.button.color**
 
-Any additional style for the Pagination. Expects `string | (props) => {}`.
+The color of the text label. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+text-strong
+```
+
+**pagination.button.hover.background.color**
+
+Background color when the button when hovered. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+background-contrast
+```
+
+**pagination.button.hover.color**
+
+The color of the text label when hovered. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
@@ -243,24 +237,309 @@ Defaults to
 undefined
 ```
 
-**global.edgeSize**
+**pagination.container**
 
-The possible sizes for margin. Expects `object`.
+Any valid Box property affecting the Box 
+    wrapping the pagination controls. Expects `object`.
 
 Defaults to
 
 ```
-{
-    edgeSize: {
-      none: '0px',
-      hair: '1px',
-      xxsmall: '3px',
-      xsmall: '6px',
-      small: '12px',
-      medium: '24px',
-      large: '48px',
-      xlarge: '96px',
-      responsiveBreakpoint: 'small',
-    },
-  }
+undefined
+```
+
+**pagination.container.extend**
+
+Any additional style for the Box wrapping 
+    the pagination controls. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**pagination.control.extend**
+
+Any additional style for each pagination control. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**pagination.control.pad**
+
+Padding around each pagination control's label. Expects `string | object`.
+
+Defaults to
+
+```
+4px
+```
+
+**pagination.control.size.small.border.radius**
+
+Rounding of the corners for each control. Expects `string`.
+
+Defaults to
+
+```
+3px
+```
+
+**pagination.control.size.small.border.width**
+
+Border thickness for each control. Expects `string`.
+
+Defaults to
+
+```
+2px
+```
+
+**pagination.control.size.small.font.size**
+
+The font size of each control's label. Expects `string`.
+
+Defaults to
+
+```
+14px
+```
+
+**pagination.control.size.small.font.height**
+
+The line-height of each control's label. Expects `string`.
+
+Defaults to
+
+```
+20px
+```
+
+**pagination.control.size.small.height**
+
+The height for each pagination control. Expects `string`.
+
+Defaults to
+
+```
+30px
+```
+
+**pagination.control.size.small.width**
+
+The minimum width for each pagination control. 
+    Width will scale up fitting the control's label. Expects `string`.
+
+Defaults to
+
+```
+30px
+```
+
+**pagination.control.size.medium.border.radius**
+
+Rounding of the corners for each control. Expects `string`.
+
+Defaults to
+
+```
+4px
+```
+
+**pagination.control.size.medium.border.width**
+
+Border thickness for each control. Expects `string`.
+
+Defaults to
+
+```
+2px
+```
+
+**pagination.control.size.medium.font.size**
+
+The font size of each control's label. Expects `string`.
+
+Defaults to
+
+```
+18px
+```
+
+**pagination.control.size.medium.font.height**
+
+The line-height of each control's label. Expects `string`.
+
+Defaults to
+
+```
+24px
+```
+
+**pagination.control.size.medium.height**
+
+The height for each pagination control. Expects `string`.
+
+Defaults to
+
+```
+36px
+```
+
+**pagination.control.size.medium.width**
+
+The minimum width for each pagination control. 
+    Width will scale up fitting the control's label. Expects `string`.
+
+Defaults to
+
+```
+36px
+```
+
+**pagination.control.size.large.border.radius**
+
+Rounding of the corners for each control. Expects `string`.
+
+Defaults to
+
+```
+4px
+```
+
+**pagination.control.size.large.border.width**
+
+Border thickness for each control. Expects `string`.
+
+Defaults to
+
+```
+6px
+```
+
+**pagination.control.size.large.font.size**
+
+The font size of each control's label. Expects `string`.
+
+Defaults to
+
+```
+22px
+```
+
+**pagination.control.size.large.font.height**
+
+The line-height of each control's label. Expects `string`.
+
+Defaults to
+
+```
+28px
+```
+
+**pagination.control.size.large.height**
+
+The height for each pagination control. Expects `string`.
+
+Defaults to
+
+```
+48px
+```
+
+**pagination.control.size.large.width**
+
+The minimum width for each pagination control. 
+    Width will scale up fitting the control's label. Expects `string`.
+
+Defaults to
+
+```
+48px
+```
+
+**pagination.controls.align**
+
+How the pagination controls should be aligned 
+    within the containing Box. Expects `string`.
+
+Defaults to
+
+```
+center
+```
+
+**pagination.controls.direction**
+
+Direction in which the containing Box should 
+    display the pagination controls. Expects `string`.
+
+Defaults to
+
+```
+row
+```
+
+**pagination.controls.gap**
+
+Amount of gap spacing between each control. Expects `string`.
+
+Defaults to
+
+```
+xxsmall
+```
+
+**pagination.controls.margin**
+
+Amount of margin surrounding the controls. Expects `string`.
+
+Defaults to
+
+```
+none
+```
+
+**pagination.controls.pad**
+
+Amount of pad surrounding the controls. Expects `string`.
+
+Defaults to
+
+```
+none
+```
+
+**pagination.icons.color**
+
+Color to fill the controls' icons. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**pagination.icons.next**
+
+Icon to use as the 'next page' control. Expects `element`.
+
+Defaults to
+
+```
+<Next />
+```
+
+**pagination.icons.previous**
+
+Icon to use as the 'previous page' control. Expects `element`.
+
+Defaults to
+
+```
+<Previous />
 ```

--- a/src/js/components/Pagination/doc.js
+++ b/src/js/components/Pagination/doc.js
@@ -73,7 +73,7 @@ export const themeDoc = {
     defaultValue: 'text-strong',
   },
   'pagination.button.hover.background.color': {
-    description: 'Background color when the button when hovered.',
+    description: 'Background color of the button when hovered.',
     type: 'string | { dark: string, light: string }',
     defaultValue: 'background-contrast',
   },
@@ -83,8 +83,8 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'pagination.container': {
-    description: `Any valid Box property affecting the Box 
-    wrapping the pagination controls.`,
+    description: `Any valid Box props for the Box wrapping the 
+    pagination controls.`,
     type: 'object',
   },
   'pagination.container.extend': {
@@ -93,11 +93,11 @@ export const themeDoc = {
     type: 'string | (props) => {}',
   },
   'pagination.control.extend': {
-    description: `Any additional style for each pagination control.`,
+    description: `Any additional style for each control.`,
     type: 'string | (props) => {}',
   },
   'pagination.control.pad': {
-    description: `Padding around each pagination control's label.`,
+    description: `Padding around each control's label.`,
     type: 'string | object',
     defaultValue: '4px',
   },
@@ -122,12 +122,12 @@ export const themeDoc = {
     defaultValue: '20px',
   },
   'pagination.control.size.small.height': {
-    description: `The height for each pagination control.`,
+    description: `The height for each control.`,
     type: 'string',
     defaultValue: '30px',
   },
   'pagination.control.size.small.width': {
-    description: `The minimum width for each pagination control. 
+    description: `The minimum width for each control. 
     Width will scale up fitting the control's label.`,
     type: 'string',
     defaultValue: '30px',
@@ -153,12 +153,12 @@ export const themeDoc = {
     defaultValue: '24px',
   },
   'pagination.control.size.medium.height': {
-    description: `The height for each pagination control.`,
+    description: `The height for each control.`,
     type: 'string',
     defaultValue: '36px',
   },
   'pagination.control.size.medium.width': {
-    description: `The minimum width for each pagination control. 
+    description: `The minimum width for each control. 
     Width will scale up fitting the control's label.`,
     type: 'string',
     defaultValue: '36px',
@@ -184,12 +184,12 @@ export const themeDoc = {
     defaultValue: '28px',
   },
   'pagination.control.size.large.height': {
-    description: `The height for each pagination control.`,
+    description: `The height for each control.`,
     type: 'string',
     defaultValue: '48px',
   },
   'pagination.control.size.large.width': {
-    description: `The minimum width for each pagination control. 
+    description: `The minimum width for each control. 
     Width will scale up fitting the control's label.`,
     type: 'string',
     defaultValue: '48px',
@@ -222,7 +222,7 @@ export const themeDoc = {
     defaultValue: 'none',
   },
   'pagination.icons.color': {
-    description: `Color to fill the controls' icons.`,
+    description: `The color used for the icon.`,
     type: 'string | { dark: string, light: string }',
   },
   'pagination.icons.next': {

--- a/src/js/components/Pagination/doc.js
+++ b/src/js/components/Pagination/doc.js
@@ -2,7 +2,6 @@ import { describe, PropTypes } from 'react-desc';
 
 import { genericProps } from '../../utils/prop-types';
 import { getAvailableAtBadge } from '../../utils/mixins';
-import { themeDocUtils } from '../../utils/themeDocUtils';
 
 export const doc = Pagination => {
   const DocumentedPagination = describe(Pagination)
@@ -21,24 +20,25 @@ export const doc = Pagination => {
     ...genericProps,
     numberEdgePages: PropTypes.number
       .description(
-        `The number of page buttons visible at the start and end of page 
+        `The number of pagination buttons visible at the start and end of page 
         range.`,
       )
       .defaultValue(1),
     numberItems: PropTypes.number
-      .description('The number of items to paginate.')
+      .description('The total number of items to paginate.')
       .defaultValue(undefined),
     numberMiddlePages: PropTypes.number
       .description(
-        `The number of page buttons visible in the middle of the controls.`,
+        `The number of pagination buttons visible in the middle of the 
+        controls.`,
       )
       .defaultValue(3),
     onChange: PropTypes.func
       .description(
-        `Function that will be called when the user clicks a page or 
-        arrow button. The single argument is an event containing the latest 
-        page via \`event.page\`, and the startIndex and endIndex for data on 
-        this page via \`event.startIndex\` and \`event.endIndex\`, 
+        `Function called when the user clicks a page or arrow button. The 
+        single argument is an event containing the target page via 
+        \`event.page\`, and the startIndex and endIndex for items contained 
+        in the target page via \`event.startIndex\` and \`event.endIndex\`, 
         respectively.`,
       )
       .defaultValue(undefined),
@@ -62,42 +62,177 @@ export const doc = Pagination => {
 };
 
 export const themeDoc = {
-  pagination: {
-    description: `The possible sizes of the Pagination in terms of its 
-      max-width, font-size and line-height.`,
-    type: 'object',
-    defaultValue: `{
-      small: {
-        size: '14px',
-        height: '20px',
-        maxWidth: '336px',
-       },
-      medium: {
-        size: '18px',
-        height: '24px',
-        maxWidth: '432px',
-      },
-      large: {
-        size: '22px',
-        height: '28px',
-        maxWidth: '528px',
-      },
-      xlarge: {
-        size: '26px',
-        height: '32px',
-        maxWidth: '624px',
-      },
-      xxlarge: {
-        size: '34px',
-        height: '40px',
-        maxWidth: '816px',
-      },
-    }`,
+  'pagination.button.active.background.color': {
+    description: `Background color when the button is active.`,
+    type: 'string | { dark: string, light: string }',
+    defaultValue: 'active-background',
   },
-  'pagination.extend': {
-    description: 'Any additional style for the Pagination.',
-    type: 'string | (props) => {}',
+  'pagination.button.color': {
+    description: `The color of the text label.`,
+    type: 'string | { dark: string, light: string }',
+    defaultValue: 'text-strong',
+  },
+  'pagination.button.hover.background.color': {
+    description: 'Background color when the button when hovered.',
+    type: 'string | { dark: string, light: string }',
+    defaultValue: 'background-contrast',
+  },
+  'pagination.button.hover.color': {
+    description: 'The color of the text label when hovered.',
+    type: 'string | { dark: string, light: string }',
     defaultValue: undefined,
   },
-  ...themeDocUtils.edgeStyle('The possible sizes for margin.'),
+  'pagination.container': {
+    description: `Any valid Box property affecting the Box 
+    wrapping the pagination controls.`,
+    type: 'object',
+  },
+  'pagination.container.extend': {
+    description: `Any additional style for the Box wrapping 
+    the pagination controls.`,
+    type: 'string | (props) => {}',
+  },
+  'pagination.control.extend': {
+    description: `Any additional style for each pagination control.`,
+    type: 'string | (props) => {}',
+  },
+  'pagination.control.pad': {
+    description: `Padding around each pagination control's label.`,
+    type: 'string | object',
+    defaultValue: '4px',
+  },
+  'pagination.control.size.small.border.radius': {
+    description: `Rounding of the corners for each control.`,
+    type: 'string',
+    defaultValue: '3px',
+  },
+  'pagination.control.size.small.border.width': {
+    description: `Border thickness for each control.`,
+    type: 'string',
+    defaultValue: '2px',
+  },
+  'pagination.control.size.small.font.size': {
+    description: `The font size of each control's label.`,
+    type: 'string',
+    defaultValue: '14px',
+  },
+  'pagination.control.size.small.font.height': {
+    description: `The line-height of each control's label.`,
+    type: 'string',
+    defaultValue: '20px',
+  },
+  'pagination.control.size.small.height': {
+    description: `The height for each pagination control.`,
+    type: 'string',
+    defaultValue: '30px',
+  },
+  'pagination.control.size.small.width': {
+    description: `The minimum width for each pagination control. 
+    Width will scale up fitting the control's label.`,
+    type: 'string',
+    defaultValue: '30px',
+  },
+  'pagination.control.size.medium.border.radius': {
+    description: `Rounding of the corners for each control.`,
+    type: 'string',
+    defaultValue: '4px',
+  },
+  'pagination.control.size.medium.border.width': {
+    description: `Border thickness for each control.`,
+    type: 'string',
+    defaultValue: '2px',
+  },
+  'pagination.control.size.medium.font.size': {
+    description: `The font size of each control's label.`,
+    type: 'string',
+    defaultValue: '18px',
+  },
+  'pagination.control.size.medium.font.height': {
+    description: `The line-height of each control's label.`,
+    type: 'string',
+    defaultValue: '24px',
+  },
+  'pagination.control.size.medium.height': {
+    description: `The height for each pagination control.`,
+    type: 'string',
+    defaultValue: '36px',
+  },
+  'pagination.control.size.medium.width': {
+    description: `The minimum width for each pagination control. 
+    Width will scale up fitting the control's label.`,
+    type: 'string',
+    defaultValue: '36px',
+  },
+  'pagination.control.size.large.border.radius': {
+    description: `Rounding of the corners for each control.`,
+    type: 'string',
+    defaultValue: '4px',
+  },
+  'pagination.control.size.large.border.width': {
+    description: `Border thickness for each control.`,
+    type: 'string',
+    defaultValue: '6px',
+  },
+  'pagination.control.size.large.font.size': {
+    description: `The font size of each control's label.`,
+    type: 'string',
+    defaultValue: '22px',
+  },
+  'pagination.control.size.large.font.height': {
+    description: `The line-height of each control's label.`,
+    type: 'string',
+    defaultValue: '28px',
+  },
+  'pagination.control.size.large.height': {
+    description: `The height for each pagination control.`,
+    type: 'string',
+    defaultValue: '48px',
+  },
+  'pagination.control.size.large.width': {
+    description: `The minimum width for each pagination control. 
+    Width will scale up fitting the control's label.`,
+    type: 'string',
+    defaultValue: '48px',
+  },
+  'pagination.controls.align': {
+    description: `How the pagination controls should be aligned 
+    within the containing Box.`,
+    type: 'string',
+    defaultValue: 'center',
+  },
+  'pagination.controls.direction': {
+    description: `Direction in which the containing Box should 
+    display the pagination controls.`,
+    type: 'string',
+    defaultValue: 'row',
+  },
+  'pagination.controls.gap': {
+    description: `Amount of gap spacing between each control.`,
+    type: 'string',
+    defaultValue: 'xxsmall',
+  },
+  'pagination.controls.margin': {
+    description: `Amount of margin surrounding the controls.`,
+    type: 'string',
+    defaultValue: 'none',
+  },
+  'pagination.controls.pad': {
+    description: `Amount of pad surrounding the controls.`,
+    type: 'string',
+    defaultValue: 'none',
+  },
+  'pagination.icons.color': {
+    description: `Color to fill the controls' icons.`,
+    type: 'string | { dark: string, light: string }',
+  },
+  'pagination.icons.next': {
+    description: `Icon to use as the 'next page' control.`,
+    type: 'element',
+    defaultValue: '<Next />',
+  },
+  'pagination.icons.previous': {
+    description: `Icon to use as the 'previous page' control.`,
+    type: 'element',
+    defaultValue: '<Previous />',
+  },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12735,7 +12735,7 @@ text-strong
 
 **pagination.button.hover.background.color**
 
-Background color when the button when hovered. Expects \`string | { dark: string, light: string }\`.
+Background color of the button when hovered. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
@@ -12755,8 +12755,8 @@ undefined
 
 **pagination.container**
 
-Any valid Box property affecting the Box 
-    wrapping the pagination controls. Expects \`object\`.
+Any valid Box props for the Box wrapping the 
+    pagination controls. Expects \`object\`.
 
 Defaults to
 
@@ -12777,7 +12777,7 @@ undefined
 
 **pagination.control.extend**
 
-Any additional style for each pagination control. Expects \`string | (props) => {}\`.
+Any additional style for each control. Expects \`string | (props) => {}\`.
 
 Defaults to
 
@@ -12787,7 +12787,7 @@ undefined
 
 **pagination.control.pad**
 
-Padding around each pagination control's label. Expects \`string | object\`.
+Padding around each control's label. Expects \`string | object\`.
 
 Defaults to
 
@@ -12837,7 +12837,7 @@ Defaults to
 
 **pagination.control.size.small.height**
 
-The height for each pagination control. Expects \`string\`.
+The height for each control. Expects \`string\`.
 
 Defaults to
 
@@ -12847,7 +12847,7 @@ Defaults to
 
 **pagination.control.size.small.width**
 
-The minimum width for each pagination control. 
+The minimum width for each control. 
     Width will scale up fitting the control's label. Expects \`string\`.
 
 Defaults to
@@ -12898,7 +12898,7 @@ Defaults to
 
 **pagination.control.size.medium.height**
 
-The height for each pagination control. Expects \`string\`.
+The height for each control. Expects \`string\`.
 
 Defaults to
 
@@ -12908,7 +12908,7 @@ Defaults to
 
 **pagination.control.size.medium.width**
 
-The minimum width for each pagination control. 
+The minimum width for each control. 
     Width will scale up fitting the control's label. Expects \`string\`.
 
 Defaults to
@@ -12959,7 +12959,7 @@ Defaults to
 
 **pagination.control.size.large.height**
 
-The height for each pagination control. Expects \`string\`.
+The height for each control. Expects \`string\`.
 
 Defaults to
 
@@ -12969,7 +12969,7 @@ Defaults to
 
 **pagination.control.size.large.width**
 
-The minimum width for each pagination control. 
+The minimum width for each control. 
     Width will scale up fitting the control's label. Expects \`string\`.
 
 Defaults to
@@ -13032,7 +13032,7 @@ none
 
 **pagination.icons.color**
 
-Color to fill the controls' icons. Expects \`string | { dark: string, light: string }\`.
+The color used for the icon. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12643,7 +12643,7 @@ string
 
 **numberEdgePages**
 
-The number of page buttons visible at the start and end of page 
+The number of pagination buttons visible at the start and end of page 
         range. Defaults to \`1\`.
 
 \`\`\`
@@ -12652,7 +12652,7 @@ number
 
 **numberItems**
 
-The number of items to paginate.
+The total number of items to paginate.
 
 \`\`\`
 number
@@ -12660,7 +12660,8 @@ number
 
 **numberMiddlePages**
 
-The number of page buttons visible in the middle of the controls. Defaults to \`3\`.
+The number of pagination buttons visible in the middle of the 
+        controls. Defaults to \`3\`.
 
 \`\`\`
 number
@@ -12668,10 +12669,10 @@ number
 
 **onChange**
 
-Function that will be called when the user clicks a page or 
-        arrow button. The single argument is an event containing the latest 
-        page via \`event.page\`, and the startIndex and endIndex for data on 
-        this page via \`event.startIndex\` and \`event.endIndex\`, 
+Function called when the user clicks a page or arrow button. The 
+        single argument is an event containing the target page via 
+        \`event.page\`, and the startIndex and endIndex for items contained 
+        in the target page via \`event.startIndex\` and \`event.endIndex\`, 
         respectively.
 
 \`\`\`
@@ -12712,46 +12713,39 @@ nav
 \`\`\`
 ## Theme
   
-**pagination**
+**pagination.button.active.background.color**
 
-The possible sizes of the Pagination in terms of its 
-      max-width, font-size and line-height. Expects \`object\`.
+Background color when the button is active. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
 \`\`\`
-{
-      small: {
-        size: '14px',
-        height: '20px',
-        maxWidth: '336px',
-       },
-      medium: {
-        size: '18px',
-        height: '24px',
-        maxWidth: '432px',
-      },
-      large: {
-        size: '22px',
-        height: '28px',
-        maxWidth: '528px',
-      },
-      xlarge: {
-        size: '26px',
-        height: '32px',
-        maxWidth: '624px',
-      },
-      xxlarge: {
-        size: '34px',
-        height: '40px',
-        maxWidth: '816px',
-      },
-    }
+active-background
 \`\`\`
 
-**pagination.extend**
+**pagination.button.color**
 
-Any additional style for the Pagination. Expects \`string | (props) => {}\`.
+The color of the text label. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+text-strong
+\`\`\`
+
+**pagination.button.hover.background.color**
+
+Background color when the button when hovered. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+background-contrast
+\`\`\`
+
+**pagination.button.hover.color**
+
+The color of the text label when hovered. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
@@ -12759,26 +12753,311 @@ Defaults to
 undefined
 \`\`\`
 
-**global.edgeSize**
+**pagination.container**
 
-The possible sizes for margin. Expects \`object\`.
+Any valid Box property affecting the Box 
+    wrapping the pagination controls. Expects \`object\`.
 
 Defaults to
 
 \`\`\`
-{
-    edgeSize: {
-      none: '0px',
-      hair: '1px',
-      xxsmall: '3px',
-      xsmall: '6px',
-      small: '12px',
-      medium: '24px',
-      large: '48px',
-      xlarge: '96px',
-      responsiveBreakpoint: 'small',
-    },
-  }
+undefined
+\`\`\`
+
+**pagination.container.extend**
+
+Any additional style for the Box wrapping 
+    the pagination controls. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**pagination.control.extend**
+
+Any additional style for each pagination control. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**pagination.control.pad**
+
+Padding around each pagination control's label. Expects \`string | object\`.
+
+Defaults to
+
+\`\`\`
+4px
+\`\`\`
+
+**pagination.control.size.small.border.radius**
+
+Rounding of the corners for each control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+3px
+\`\`\`
+
+**pagination.control.size.small.border.width**
+
+Border thickness for each control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
+\`\`\`
+
+**pagination.control.size.small.font.size**
+
+The font size of each control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+14px
+\`\`\`
+
+**pagination.control.size.small.font.height**
+
+The line-height of each control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+20px
+\`\`\`
+
+**pagination.control.size.small.height**
+
+The height for each pagination control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+30px
+\`\`\`
+
+**pagination.control.size.small.width**
+
+The minimum width for each pagination control. 
+    Width will scale up fitting the control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+30px
+\`\`\`
+
+**pagination.control.size.medium.border.radius**
+
+Rounding of the corners for each control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+4px
+\`\`\`
+
+**pagination.control.size.medium.border.width**
+
+Border thickness for each control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
+\`\`\`
+
+**pagination.control.size.medium.font.size**
+
+The font size of each control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+18px
+\`\`\`
+
+**pagination.control.size.medium.font.height**
+
+The line-height of each control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+24px
+\`\`\`
+
+**pagination.control.size.medium.height**
+
+The height for each pagination control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+36px
+\`\`\`
+
+**pagination.control.size.medium.width**
+
+The minimum width for each pagination control. 
+    Width will scale up fitting the control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+36px
+\`\`\`
+
+**pagination.control.size.large.border.radius**
+
+Rounding of the corners for each control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+4px
+\`\`\`
+
+**pagination.control.size.large.border.width**
+
+Border thickness for each control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+6px
+\`\`\`
+
+**pagination.control.size.large.font.size**
+
+The font size of each control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+22px
+\`\`\`
+
+**pagination.control.size.large.font.height**
+
+The line-height of each control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+28px
+\`\`\`
+
+**pagination.control.size.large.height**
+
+The height for each pagination control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+48px
+\`\`\`
+
+**pagination.control.size.large.width**
+
+The minimum width for each pagination control. 
+    Width will scale up fitting the control's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+48px
+\`\`\`
+
+**pagination.controls.align**
+
+How the pagination controls should be aligned 
+    within the containing Box. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+center
+\`\`\`
+
+**pagination.controls.direction**
+
+Direction in which the containing Box should 
+    display the pagination controls. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+row
+\`\`\`
+
+**pagination.controls.gap**
+
+Amount of gap spacing between each control. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+xxsmall
+\`\`\`
+
+**pagination.controls.margin**
+
+Amount of margin surrounding the controls. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+none
+\`\`\`
+
+**pagination.controls.pad**
+
+Amount of pad surrounding the controls. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+none
+\`\`\`
+
+**pagination.icons.color**
+
+Color to fill the controls' icons. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**pagination.icons.next**
+
+Icon to use as the 'next page' control. Expects \`element\`.
+
+Defaults to
+
+\`\`\`
+<Next />
+\`\`\`
+
+**pagination.icons.previous**
+
+Icon to use as the 'previous page' control. Expects \`element\`.
+
+Defaults to
+
+\`\`\`
+<Previous />
 \`\`\`
 ",
   "Paragraph": "## Paragraph

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5998,29 +5998,30 @@ string",
       },
       Object {
         "defaultValue": 1,
-        "description": "The number of page buttons visible at the start and end of page 
+        "description": "The number of pagination buttons visible at the start and end of page 
         range.",
         "format": "number",
         "name": "numberEdgePages",
       },
       Object {
         "defaultValue": undefined,
-        "description": "The number of items to paginate.",
+        "description": "The total number of items to paginate.",
         "format": "number",
         "name": "numberItems",
       },
       Object {
         "defaultValue": 3,
-        "description": "The number of page buttons visible in the middle of the controls.",
+        "description": "The number of pagination buttons visible in the middle of the 
+        controls.",
         "format": "number",
         "name": "numberMiddlePages",
       },
       Object {
         "defaultValue": undefined,
-        "description": "Function that will be called when the user clicks a page or 
-        arrow button. The single argument is an event containing the latest 
-        page via \`event.page\`, and the startIndex and endIndex for data on 
-        this page via \`event.startIndex\` and \`event.endIndex\`, 
+        "description": "Function called when the user clicks a page or arrow button. The 
+        single argument is an event containing the target page via 
+        \`event.page\`, and the startIndex and endIndex for items contained 
+        in the target page via \`event.startIndex\` and \`event.endIndex\`, 
         respectively.",
         "format": "function",
         "name": "onChange",

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -951,14 +951,13 @@ export interface ThemeType {
     extend?: ExtendType;
   };
   pagination?: {
-    container?: BoxProps;
     button?: {
-      color?: ColorType;
       active?: {
         background?: {
           color?: ColorType;
         };
       };
+      color?: ColorType;
       hover?: {
         background?: {
           color?: ColorType;
@@ -966,6 +965,7 @@ export interface ThemeType {
         color?: ColorType;
       };
     };
+    container?: BoxProps;
     control?: {
       extend?: ExtendType;
       pad?: PadType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -951,17 +951,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // extend: undefined,
     },
     pagination: {
-      // container: {
-      //   // any box props,
-      //   extend: undefined,
-      // },
       button: {
-        color: 'text-strong',
         active: {
           background: {
             color: 'active-background',
           },
         },
+        color: 'text-strong',
         hover: {
           background: {
             color: 'background-contrast',
@@ -969,6 +965,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           color: undefined,
         },
       },
+      // container: {
+      //   // any box props,
+      //   extend: undefined,
+      // },
       control: {
         // extend: undefined,
         pad: '4px',
@@ -1006,8 +1006,8 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         align: 'center',
         direction: 'row',
         gap: 'xxsmall',
-        pad: 'none',
         margin: 'none',
+        pad: 'none',
       },
       icons: {
         // color: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds pagination themeDocs, plus some minimal re-org of theme definitions (alphabetizing)

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
