### PR TITLE
Proposal for showSummary prop

### DIFF
--- a/src/js/components/DataTable/stories/Paginated.js
+++ b/src/js/components/DataTable/stories/Paginated.js
@@ -16,8 +16,7 @@ export const Paginated = () => {
           select={select}
           sortable
           step={3}
-          // paginate={{ showSummary: true }}
-          paginate
+          paginate={{ showSummary: true }}
         />
       </Box>
     </Grommet>

--- a/src/js/components/DataTable/stories/Paginated.js
+++ b/src/js/components/DataTable/stories/Paginated.js
@@ -16,7 +16,7 @@ export const Paginated = () => {
           select={select}
           sortable
           step={3}
-          paginate={{ showSummary: true }}
+          paginate={{ summary: true }}
         />
       </Box>
     </Grommet>

--- a/src/js/components/DataTable/stories/Paginated.js
+++ b/src/js/components/DataTable/stories/Paginated.js
@@ -16,6 +16,7 @@ export const Paginated = () => {
           select={select}
           sortable
           step={3}
+          // paginate={{ showSummary: true }}
           paginate
         />
       </Box>

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -43,9 +43,6 @@ const Pagination = forwardRef(
       Math.min(pageProp, totalPages) || 1,
     );
 
-    const itemsBegin = step * (activePage - 1) + 1;
-    const itemsEnd = itemsBegin + step - 1;
-
     /* Define page indices to display */
     const beginPages = getPageIndices(1, Math.min(numberEdgePages, totalPages));
     const endPages = getPageIndices(
@@ -181,6 +178,8 @@ const Pagination = forwardRef(
       ...navProps[control],
     }));
 
+    const itemsBegin = step * (activePage - 1) + 1;
+    const itemsEnd = itemsBegin + step - 1;
     let showSummary;
     if (showSummaryProp === true)
       showSummary = (
@@ -192,7 +191,7 @@ const Pagination = forwardRef(
 
     // only apply these if the caller hasn't already specified their own theming
     // otherwise, let the caller control
-    const showSummaryContainerProps =
+    const showSummaryStyles =
       showSummary && !theme.pagination.container
         ? {
             align: 'center',
@@ -205,7 +204,7 @@ const Pagination = forwardRef(
     return (
       <StyledPaginationContainer
         {...theme.pagination.container}
-        {...showSummaryContainerProps}
+        {...showSummaryStyles}
         {...rest}
       >
         {showSummary}

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -28,7 +28,7 @@ const Pagination = forwardRef(
       numberMiddlePages: numberMiddlePagesProp = 3,
       onChange,
       page: pageProp,
-      showSummary: showSummaryProp,
+      summary: summaryProp,
       size,
       step = 10,
       ...rest
@@ -180,19 +180,19 @@ const Pagination = forwardRef(
 
     const itemsBegin = step * (activePage - 1) + 1;
     const itemsEnd = itemsBegin + step - 1;
-    let showSummary;
-    if (showSummaryProp === true)
-      showSummary = (
+    let summary;
+    if (summaryProp === true)
+      summary = (
         <Text>
           Showing {itemsBegin} - {itemsEnd} of {numberItems}
         </Text>
       );
-    else showSummary = showSummaryProp;
+    else summary = summaryProp;
 
     // only apply these if the caller hasn't already specified their own theming
     // otherwise, let the caller control
-    const showSummaryStyles =
-      showSummary && !theme.pagination.container
+    const summaryStyles =
+      summary && !theme.pagination.container
         ? {
             align: 'center',
             fill: 'horizontal',
@@ -204,10 +204,10 @@ const Pagination = forwardRef(
     return (
       <StyledPaginationContainer
         {...theme.pagination.container}
-        {...showSummaryStyles}
+        {...summaryStyles}
         {...rest}
       >
-        {showSummary}
+        {summary}
         <Nav
           a11yTitle={a11yTitle || 'Pagination Navigation'}
           ref={ref}

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -2,6 +2,7 @@ import React, { forwardRef, useContext, useState } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { Box } from '../Box';
 import { Nav } from '../Nav';
+import { Text } from '../Text';
 import { PageControl } from './PageControl';
 
 const StyledPaginationContainer = styled(Box)`
@@ -27,6 +28,7 @@ const Pagination = forwardRef(
       numberMiddlePages: numberMiddlePagesProp = 3,
       onChange,
       page: pageProp,
+      showSummary: showSummaryProp,
       size,
       step = 10,
       ...rest
@@ -40,6 +42,9 @@ const Pagination = forwardRef(
     const [activePage, setActivePage] = useState(
       Math.min(pageProp, totalPages) || 1,
     );
+
+    const itemsBegin = step * (activePage - 1) + 1;
+    const itemsEnd = itemsBegin + step - 1;
 
     /* Define page indices to display */
     const beginPages = getPageIndices(1, Math.min(numberEdgePages, totalPages));
@@ -176,9 +181,39 @@ const Pagination = forwardRef(
       ...navProps[control],
     }));
 
+    let showSummary;
+    if (showSummaryProp === true)
+      showSummary = (
+        <Text>
+          Showing {itemsBegin} - {itemsEnd} of {numberItems}
+        </Text>
+      );
+    else showSummary = showSummaryProp;
+
+    // only apply these if the caller hasn't already specified their own theming
+    // otherwise, let the caller control
+    const showSummaryContainerProps =
+      showSummary && !theme.pagination.container
+        ? {
+            align: 'center',
+            fill: 'horizontal',
+            direction: 'row',
+            justify: 'between',
+          }
+        : undefined;
+
     return (
-      <StyledPaginationContainer {...theme.pagination.container} {...rest}>
-        <Nav a11yTitle={a11yTitle || 'Pagination Navigation'} ref={ref}>
+      <StyledPaginationContainer
+        {...theme.pagination.container}
+        {...showSummaryContainerProps}
+        {...rest}
+      >
+        {showSummary}
+        <Nav
+          a11yTitle={a11yTitle || 'Pagination Navigation'}
+          ref={ref}
+          {...theme.pagination.nav}
+        >
           <Box as="ul" {...theme.pagination.controls}>
             {controls.map(control => (
               <PageControl key={control.a11yTitle} size={size} {...control} />

--- a/src/js/components/Pagination/README.md
+++ b/src/js/components/Pagination/README.md
@@ -172,7 +172,7 @@ The default page. If used with onChange, it can be used to control the
 number
 ```
 
-**showSummary**
+**summary**
 
 Whether to display a summary of what range of results are 
       being displayed. If true, this will be displayed in the format of 

--- a/src/js/components/Pagination/README.md
+++ b/src/js/components/Pagination/README.md
@@ -172,6 +172,17 @@ The default page. If used with onChange, it can be used to control the
 number
 ```
 
+**showSummary**
+
+Whether to display a summary of what range of results are 
+      being displayed. If true, this will be displayed in the format of 
+      "Showing X - Y of Z". Alternately, a custom JSX element can be provided.
+
+```
+boolean
+element
+```
+
 **size**
 
 Specifies what size the pagination control buttons should be. Defaults to `medium`.

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -107,6 +107,11 @@ exports[`Pagination should allow user to control page via state with page +
   width: 3px;
 }
 
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c9 {
   display: inline-block;
   box-sizing: border-box;
@@ -228,11 +233,6 @@ exports[`Pagination should allow user to control page via state with page +
 
 .c5:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -571,6 +571,11 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   width: 3px;
 }
 
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -758,11 +763,6 @@ exports[`Pagination should apply button kind style when referenced by a string 1
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -1149,6 +1149,11 @@ exports[`Pagination should apply custom theme 1`] = `
   width: 3px;
 }
 
+.c13 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c6 {
   display: inline-block;
   box-sizing: border-box;
@@ -1327,11 +1332,6 @@ exports[`Pagination should apply custom theme 1`] = `
 
 .c12:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c13 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c7 {
@@ -1722,6 +1722,11 @@ exports[`Pagination should apply size 1`] = `
   width: 3px;
 }
 
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -1900,11 +1905,6 @@ exports[`Pagination should apply size 1`] = `
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -2731,6 +2731,11 @@ exports[`Pagination should disable next button if on last page 1`] = `
   width: 3px;
 }
 
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -2909,11 +2914,6 @@ exports[`Pagination should disable next button if on last page 1`] = `
 
 .c12:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -4344,6 +4344,11 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   width: 3px;
 }
 
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -4522,11 +4527,6 @@ exports[`Pagination should disable previous button if on first page 1`] = `
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -4880,6 +4880,11 @@ exports[`Pagination should display next page of results when "next" is
   width: 3px;
 }
 
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c9 {
   display: inline-block;
   box-sizing: border-box;
@@ -5001,11 +5006,6 @@ exports[`Pagination should display next page of results when "next" is
 
 .c5:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -5519,6 +5519,11 @@ exports[`Pagination should display page 'n' of results when "page n" is
   width: 3px;
 }
 
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c9 {
   display: inline-block;
   box-sizing: border-box;
@@ -5640,11 +5645,6 @@ exports[`Pagination should display page 'n' of results when "page n" is
 
 .c5:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -5984,6 +5984,11 @@ exports[`Pagination should display previous page of results when "previous" is
   width: 3px;
 }
 
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -6105,11 +6110,6 @@ exports[`Pagination should display previous page of results when "previous" is
 
 .c9:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -6657,6 +6657,11 @@ exports[`Pagination should display the correct last page based on items length
   width: 3px;
 }
 
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -6835,11 +6840,6 @@ exports[`Pagination should display the correct last page based on items length
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -7192,6 +7192,11 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   width: 3px;
 }
 
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -7313,11 +7318,6 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -7713,6 +7713,11 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   width: 3px;
 }
 
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -7834,11 +7839,6 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -8189,6 +8189,11 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   width: 3px;
 }
 
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -8310,11 +8315,6 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -8714,6 +8714,11 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   width: 3px;
 }
 
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -8892,11 +8897,6 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 
 .c11:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {
@@ -9254,6 +9254,11 @@ exports[`Pagination should set page to last page if page prop > total possible
   width: 3px;
 }
 
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -9432,11 +9437,6 @@ exports[`Pagination should set page to last page if page prop > total possible
 
 .c12:focus::-moz-focus-inner {
   border: 0;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c6 {

--- a/src/js/components/Pagination/doc.js
+++ b/src/js/components/Pagination/doc.js
@@ -48,6 +48,13 @@ export const doc = Pagination => {
         active page via state.`,
       )
       .defaultValue(undefined),
+    showSummary: PropTypes.oneOfType([PropTypes.bool, PropTypes.element])
+      .description(
+        `Whether to display a summary of what range of results are 
+      being displayed. If true, this will be displayed in the format of 
+      "Showing X - Y of Z". Alternately, a custom JSX element can be provided.`,
+      )
+      .defaultValue(undefined),
     size: PropTypes.oneOf(['small', 'medium', 'large'])
       .description(
         'Specifies what size the pagination control buttons should be.',

--- a/src/js/components/Pagination/doc.js
+++ b/src/js/components/Pagination/doc.js
@@ -48,7 +48,7 @@ export const doc = Pagination => {
         active page via state.`,
       )
       .defaultValue(undefined),
-    showSummary: PropTypes.oneOfType([PropTypes.bool, PropTypes.element])
+    summary: PropTypes.oneOfType([PropTypes.bool, PropTypes.element])
       .description(
         `Whether to display a summary of what range of results are 
       being displayed. If true, this will be displayed in the format of 

--- a/src/js/components/Pagination/index.d.ts
+++ b/src/js/components/Pagination/index.d.ts
@@ -16,6 +16,7 @@ export interface PaginationProps {
   numberMiddlePages?: number;
   onChange?: (...args: any[]) => void;
   page?: number;
+  showSummary?: boolean | JSX.Element;
   size?: 'small' | 'medium' | 'large';
   step?: number;
 }

--- a/src/js/components/Pagination/index.d.ts
+++ b/src/js/components/Pagination/index.d.ts
@@ -16,7 +16,7 @@ export interface PaginationProps {
   numberMiddlePages?: number;
   onChange?: (...args: any[]) => void;
   page?: number;
-  showSummary?: boolean | JSX.Element;
+  summary?: boolean | JSX.Element;
   size?: 'small' | 'medium' | 'large';
   step?: number;
 }

--- a/src/js/components/Pagination/stories/Pagination.stories.js
+++ b/src/js/components/Pagination/stories/Pagination.stories.js
@@ -2,6 +2,7 @@ export { Custom } from './Custom';
 export { Grid } from './Grid';
 export { NumberEdgePages } from './NumberEdgePages';
 export { NumberMiddlePages } from './NumberMiddlePages';
+export { ShowSummary } from './ShowSummary';
 export { Simple } from './Simple';
 export { Size } from './Size';
 

--- a/src/js/components/Pagination/stories/Pagination.stories.js
+++ b/src/js/components/Pagination/stories/Pagination.stories.js
@@ -2,7 +2,7 @@ export { Custom } from './Custom';
 export { Grid } from './Grid';
 export { NumberEdgePages } from './NumberEdgePages';
 export { NumberMiddlePages } from './NumberMiddlePages';
-export { ShowSummary } from './ShowSummary';
+export { Summary } from './Summary';
 export { Simple } from './Simple';
 export { Size } from './Size';
 

--- a/src/js/components/Pagination/stories/ShowSummary.js
+++ b/src/js/components/Pagination/stories/ShowSummary.js
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+
+import { Box, Grommet, Pagination, Select, Text, ThemeContext } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+export const ShowSummary = () => {
+  const numberItems = 237;
+  const [indices, setIndices] = useState([0, 10]);
+  const [step, setStep] = useState(10);
+  const [activePage, setActivePage] = useState(1);
+
+  const handleChange = ({ page, startIndex, endIndex }) => {
+    setActivePage(page);
+    setIndices([startIndex, Math.min(endIndex, numberItems)]);
+  };
+
+  useEffect(() => {
+    const itemsBeginIndex = step * (activePage - 1);
+    const itemsEndIndex = Math.min(itemsBeginIndex + step, numberItems);
+    setIndices([itemsBeginIndex, itemsEndIndex]);
+  }, [step, activePage]);
+
+  return (
+    <Grommet theme={grommet}>
+      <Box align="start" pad="small" gap="medium">
+        <Box gap="small" fill="horizontal">
+          <Text weight="bold">showSummary = true</Text>
+          <Pagination numberItems={numberItems} showSummary />
+        </Box>
+        <ThemeContext.Extend
+          value={{
+            pagination: {
+              nav: {
+                direction: 'row',
+                flex: true,
+                justify: 'end',
+              },
+            },
+          }}
+        >
+          <Box gap="small" fill="horizontal">
+            <Text weight="bold">Custom showSummary</Text>
+            <Pagination
+              numberItems={numberItems}
+              onChange={handleChange}
+              step={step}
+              showSummary={
+                <>
+                  <Box flex>
+                    <Text>
+                      Showing{' '}
+                      <Text weight="bold">
+                        {indices[0] + 1} - {indices[1]}
+                      </Text>{' '}
+                      of {numberItems} items
+                    </Text>
+                  </Box>
+                  <Box direction="row" align="center" gap="small">
+                    <Text>Show</Text>
+                    <Box width="xsmall">
+                      <Select
+                        options={[10, 25, 50]}
+                        value={step}
+                        onChange={({ option }) => setStep(option)}
+                      />
+                    </Box>
+                    <Text>items per page</Text>
+                  </Box>
+                </>
+              }
+            />
+          </Box>
+        </ThemeContext.Extend>
+      </Box>
+    </Grommet>
+  );
+};

--- a/src/js/components/Pagination/stories/Simple.js
+++ b/src/js/components/Pagination/stories/Simple.js
@@ -8,7 +8,7 @@ export const Simple = () => (
     <Box align="start" pad="small" gap="medium">
       <Box>
         <Text>Default</Text>
-        <Pagination numberItems={237} />
+        <Pagination numberItems={237} showSummary />
       </Box>
       <Box>
         <Text>Box Props</Text>

--- a/src/js/components/Pagination/stories/Simple.js
+++ b/src/js/components/Pagination/stories/Simple.js
@@ -8,7 +8,7 @@ export const Simple = () => (
     <Box align="start" pad="small" gap="medium">
       <Box>
         <Text>Default</Text>
-        <Pagination numberItems={237} showSummary />
+        <Pagination numberItems={237} summary />
       </Box>
       <Box>
         <Text>Box Props</Text>

--- a/src/js/components/Pagination/stories/Summary.js
+++ b/src/js/components/Pagination/stories/Summary.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Grommet, Pagination, Select, Text, ThemeContext } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-export const ShowSummary = () => {
+export const Summary = () => {
   const numberItems = 237;
   const [indices, setIndices] = useState([0, 10]);
   const [step, setStep] = useState(10);
@@ -24,8 +24,8 @@ export const ShowSummary = () => {
     <Grommet theme={grommet}>
       <Box align="start" pad="small" gap="medium">
         <Box gap="small" fill="horizontal">
-          <Text weight="bold">showSummary = true</Text>
-          <Pagination numberItems={numberItems} showSummary />
+          <Text weight="bold">summary = true</Text>
+          <Pagination numberItems={numberItems} summary />
         </Box>
         <ThemeContext.Extend
           value={{
@@ -39,12 +39,12 @@ export const ShowSummary = () => {
           }}
         >
           <Box gap="small" fill="horizontal">
-            <Text weight="bold">Custom showSummary</Text>
+            <Text weight="bold">Custom summary</Text>
             <Pagination
               numberItems={numberItems}
               onChange={handleChange}
               step={step}
-              showSummary={
+              summary={
                 <>
                   <Box flex>
                     <Text>

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12733,6 +12733,17 @@ The default page. If used with onChange, it can be used to control the
 number
 \`\`\`
 
+**showSummary**
+
+Whether to display a summary of what range of results are 
+      being displayed. If true, this will be displayed in the format of 
+      \\"Showing X - Y of Z\\". Alternately, a custom JSX element can be provided.
+
+\`\`\`
+boolean
+element
+\`\`\`
+
 **size**
 
 Specifies what size the pagination control buttons should be. Defaults to \`medium\`.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12733,7 +12733,7 @@ The default page. If used with onChange, it can be used to control the
 number
 \`\`\`
 
-**showSummary**
+**summary**
 
 Whether to display a summary of what range of results are 
       being displayed. If true, this will be displayed in the format of 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6044,6 +6044,15 @@ string",
         "name": "page",
       },
       Object {
+        "defaultValue": undefined,
+        "description": "Whether to display a summary of what range of results are 
+      being displayed. If true, this will be displayed in the format of 
+      \\"Showing X - Y of Z\\". Alternately, a custom JSX element can be provided.",
+        "format": "boolean
+element",
+        "name": "showSummary",
+      },
+      Object {
         "defaultValue": "medium",
         "description": "Specifies what size the pagination control buttons should be.",
         "format": "small

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6050,7 +6050,7 @@ string",
       \\"Showing X - Y of Z\\". Alternately, a custom JSX element can be provided.",
         "format": "boolean
 element",
-        "name": "showSummary",
+        "name": "summary",
       },
       Object {
         "defaultValue": "medium",

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1022,6 +1022,7 @@ export interface ThemeType {
       next?: React.ReactNode;
       previous?: React.ReactNode;
     };
+    nav?: BoxProps;
   };
   paragraph?: {
     extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -974,7 +974,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       // container: {
       //   // any box props,
-      //   extend: undefined,
+      //   // extend: undefined,
       // },
       control: {
         // extend: undefined,
@@ -1016,6 +1016,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         margin: 'none',
         pad: 'none',
       },
+      // nav: {
+      //   // any box props
+      // },
       icons: {
         // color: undefined,
         next: Next,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Looking for feedback on general direction and styling requirements.

Exploring adding a `showSummary` prop to Pagination that would display "Showing X - Y of Z". The prop accepts a boolean (which would display the default string) or a custom JSX element where users could do whatever they want. I have demoed both in "Show Summary" storybook example.

Important notes:
- For the showSummary to align nicely with the pagination controls, some default theming needs to be added to the pagination container. However, it will only apply if the user does not already have `theme.pagination.container` styling defined because I didn't want it to override users values. Is this the right approach?
- In order to achieve what is demoed in the Custom Show Summary, the user needs access to style the `nav` element, requiring I add `theme.pagination.nav`.

Storybook examples worth viewing (checkout locally):
1. Show Summary (in Pagination)
2. Paginated (in DataTable) -- added this just to make sure it would play nicely with that work

To-do, if we like this approach:
- [ ] Add tests
- [ ] Complete documentation

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
