### PR TITLE
Refactor theme to rely on pagination.button

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -36,10 +36,7 @@ const fontStyle = props => {
   `;
 };
 
-const padFromTheme = (size, theme, kind) => {
-  // caller has specified a themeObj to use for styling
-  // relevant for cases like pagination which looks to theme.pagination.button
-  const themeObj = typeof kind === 'object' ? kind : theme.button;
+const padFromTheme = (size, theme, themeObj) => {
   if (size && themeObj.size && themeObj.size[size] && themeObj.size[size].pad) {
     return {
       vertical: themeObj.size[size].pad.vertical,
@@ -61,7 +58,10 @@ const padFromTheme = (size, theme, kind) => {
 };
 
 const padStyle = ({ sizeProp: size, theme, kind }) => {
-  const pad = padFromTheme(size, theme, kind);
+  // caller has specified a themeObj to use for styling
+  // relevant for cases like pagination which looks to theme.pagination.button
+  const themeObj = typeof kind === 'object' ? kind : theme.button;
+  const pad = padFromTheme(size, theme, themeObj);
   return pad
     ? css`
         padding: ${pad.vertical} ${pad.horizontal};
@@ -106,11 +106,11 @@ const kindStyle = ({ colorValue, kind, sizeProp: size, themePaths, theme }) => {
 
   // caller has specified a themeObj to use for styling
   // relevant for cases like pagination which looks to theme.pagination.button
-  const themeObj = typeof kind === 'object' ? kind : undefined;
+  const themeObj = typeof kind === 'object' ? kind : theme.button;
 
   const pad = padFromTheme(size, theme, themeObj);
   themePaths.base.forEach(themePath => {
-    const obj = getPath(themeObj || theme.button, themePath);
+    const obj = getPath(themeObj, themePath);
     if (obj) {
       styles.push(kindPartStyles(obj, theme, colorValue));
       if (obj.border && obj.border.width && pad && !obj.padding) {
@@ -123,8 +123,8 @@ const kindStyle = ({ colorValue, kind, sizeProp: size, themePaths, theme }) => {
   });
 
   // do the styling from the root of the object if caller passes one
-  if (!themePaths.base.length && themeObj) {
-    const obj = themeObj;
+  if (!themePaths.base.length && typeof kind === 'object') {
+    const obj = kind;
     if (obj) {
       styles.push(kindPartStyles(obj, theme, colorValue));
       if (obj.border && obj.border.width && pad && !obj.padding) {
@@ -137,7 +137,7 @@ const kindStyle = ({ colorValue, kind, sizeProp: size, themePaths, theme }) => {
   }
 
   themePaths.hover.forEach(themePath => {
-    const obj = getPath(themeObj || theme.button, themePath);
+    const obj = getPath(themeObj, themePath);
 
     if (obj) {
       const partStyles = kindPartStyles(obj, theme);

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -12,13 +12,17 @@ import { defaultProps } from '../../default-props';
 
 const radiusStyle = props => {
   const size = props.sizeProp;
-  if (size && props.theme.button.size && props.theme.button.size[size])
+  // caller has specified a themeObj to use for styling
+  // relevant for cases like pagination which looks to theme.pagination.button
+  const themeObj =
+    typeof props.kind === 'object' ? props.kind : props.theme.button;
+  if (size && themeObj.size && themeObj.size[size])
     return css`
-      border-radius: ${props.theme.button.size[size].border.radius};
+      border-radius: ${themeObj.size[size].border.radius};
     `;
-  if (props.theme.button.border && props.theme.button.border.radius)
+  if (themeObj.border && themeObj.border.radius)
     return css`
-      border-radius: ${props.theme.button.border.radius};
+      border-radius: ${themeObj.border.radius};
     `;
   return '';
 };
@@ -32,16 +36,14 @@ const fontStyle = props => {
   `;
 };
 
-const padFromTheme = (size, theme) => {
-  if (
-    size &&
-    theme.button.size &&
-    theme.button.size[size] &&
-    theme.button.size[size].pad
-  ) {
+const padFromTheme = (size, theme, kind) => {
+  // caller has specified a themeObj to use for styling
+  // relevant for cases like pagination which looks to theme.pagination.button
+  const themeObj = typeof kind === 'object' ? kind : theme.button;
+  if (size && themeObj.size && themeObj.size[size] && themeObj.size[size].pad) {
     return {
-      vertical: theme.button.size[size].pad.vertical,
-      horizontal: theme.button.size[size].pad.horizontal,
+      vertical: themeObj.size[size].pad.vertical,
+      horizontal: themeObj.size[size].pad.horizontal,
     };
   }
 
@@ -58,8 +60,8 @@ const padFromTheme = (size, theme) => {
   return undefined;
 };
 
-const padStyle = ({ sizeProp: size, theme }) => {
-  const pad = padFromTheme(size, theme);
+const padStyle = ({ sizeProp: size, theme, kind }) => {
+  const pad = padFromTheme(size, theme, kind);
   return pad
     ? css`
         padding: ${pad.vertical} ${pad.horizontal};
@@ -93,8 +95,8 @@ const getPath = (theme, path) => {
 const adjustPadStyle = (pad, width) => {
   const offset = parseMetricToNum(width);
   return css`
-    padding: ${parseMetricToNum(pad.vertical) - offset}px
-      ${parseMetricToNum(pad.horizontal) - offset}px;
+    padding: ${Math.max(parseMetricToNum(pad.vertical) - offset, 0)}px
+      ${Math.max(parseMetricToNum(pad.horizontal) - offset, 0)}px;
   `;
 };
 
@@ -106,11 +108,9 @@ const kindStyle = ({ colorValue, kind, sizeProp: size, themePaths, theme }) => {
   // relevant for cases like pagination which looks to theme.pagination.button
   const themeObj = typeof kind === 'object' ? kind : undefined;
 
-  const pad = padFromTheme(size, theme);
-
+  const pad = padFromTheme(size, theme, themeObj);
   themePaths.base.forEach(themePath => {
     const obj = getPath(themeObj || theme.button, themePath);
-
     if (obj) {
       styles.push(kindPartStyles(obj, theme, colorValue));
       if (obj.border && obj.border.width && pad && !obj.padding) {
@@ -127,6 +127,12 @@ const kindStyle = ({ colorValue, kind, sizeProp: size, themePaths, theme }) => {
     const obj = themeObj;
     if (obj) {
       styles.push(kindPartStyles(obj, theme, colorValue));
+      if (obj.border && obj.border.width && pad && !obj.padding) {
+        // Adjust padding from the button.size or just top button.padding
+        // to deal with the kind's border width. But don't override any
+        // padding in the kind itself for backward compatibility
+        styles.push(adjustPadStyle(pad, obj.border.width));
+      }
     }
   }
 

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -12774,7 +12774,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12785,25 +12785,25 @@ exports[`DataTable should apply pagination styling 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*="#"],
-.c23 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*="#"],
-.c23 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -12966,8 +12966,8 @@ exports[`DataTable should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -13025,8 +13025,8 @@ exports[`DataTable should apply pagination styling 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -13074,7 +13074,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   border: 0;
 }
 
-.c22 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -13086,8 +13086,8 @@ exports[`DataTable should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -13106,31 +13106,31 @@ exports[`DataTable should apply pagination styling 1`] = `
   flex: 1 0 auto;
 }
 
-.c22 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -13177,30 +13177,11 @@ exports[`DataTable should apply pagination styling 1`] = `
 }
 
 .c17 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c17 > svg {
-  vertical-align: middle;
-}
-
-.c21 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c21:hover {
-  padding: 4px;
-}
-
-.c21 > svg {
   vertical-align: middle;
 }
 
@@ -14916,7 +14897,7 @@ exports[`DataTable should apply pagination styling 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c21"
+              class="c20 c17"
               type="button"
             >
               1
@@ -14930,7 +14911,7 @@ exports[`DataTable should apply pagination styling 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               2
@@ -14944,12 +14925,12 @@ exports[`DataTable should apply pagination styling 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -15003,7 +14984,7 @@ exports[`DataTable should paginate 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -15014,25 +14995,25 @@ exports[`DataTable should paginate 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*="#"],
-.c23 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*="#"],
-.c23 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -15193,8 +15174,8 @@ exports[`DataTable should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -15252,8 +15233,8 @@ exports[`DataTable should paginate 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -15301,7 +15282,7 @@ exports[`DataTable should paginate 1`] = `
   border: 0;
 }
 
-.c22 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -15313,8 +15294,8 @@ exports[`DataTable should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -15333,31 +15314,31 @@ exports[`DataTable should paginate 1`] = `
   flex: 1 0 auto;
 }
 
-.c22 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -15404,30 +15385,11 @@ exports[`DataTable should paginate 1`] = `
 }
 
 .c17 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c17 > svg {
-  vertical-align: middle;
-}
-
-.c21 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c21:hover {
-  padding: 4px;
-}
-
-.c21 > svg {
   vertical-align: middle;
 }
 
@@ -17137,7 +17099,7 @@ exports[`DataTable should paginate 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c21"
+              class="c20 c17"
               type="button"
             >
               1
@@ -17151,7 +17113,7 @@ exports[`DataTable should paginate 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               2
@@ -17165,12 +17127,12 @@ exports[`DataTable should paginate 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -17224,7 +17186,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -17235,25 +17197,25 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*="#"],
-.c23 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*="#"],
-.c23 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -17414,8 +17376,8 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -17473,8 +17435,8 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -17522,7 +17484,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border: 0;
 }
 
-.c22 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -17534,8 +17496,8 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -17554,31 +17516,31 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   flex: 1 0 auto;
 }
 
-.c22 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -17625,30 +17587,11 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
 }
 
 .c17 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c17 > svg {
-  vertical-align: middle;
-}
-
-.c21 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c21:hover {
-  padding: 4px;
-}
-
-.c21 > svg {
   vertical-align: middle;
 }
 
@@ -18242,7 +18185,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c21"
+              class="c20 c17"
               type="button"
             >
               1
@@ -18256,7 +18199,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               2
@@ -18270,7 +18213,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 3"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               3
@@ -18284,7 +18227,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 4"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               4
@@ -18298,7 +18241,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 5"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               5
@@ -18312,7 +18255,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 6"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               6
@@ -18326,7 +18269,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 7"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               7
@@ -18340,12 +18283,12 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -18399,7 +18342,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -18410,25 +18353,25 @@ exports[`DataTable should render new data when page changes 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*="#"],
-.c23 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*="#"],
-.c23 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -18589,8 +18532,8 @@ exports[`DataTable should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -18648,8 +18591,8 @@ exports[`DataTable should render new data when page changes 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -18697,7 +18640,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   border: 0;
 }
 
-.c22 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -18709,8 +18652,8 @@ exports[`DataTable should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -18729,31 +18672,31 @@ exports[`DataTable should render new data when page changes 1`] = `
   flex: 1 0 auto;
 }
 
-.c22 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -18800,30 +18743,11 @@ exports[`DataTable should render new data when page changes 1`] = `
 }
 
 .c17 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c17 > svg {
-  vertical-align: middle;
-}
-
-.c21 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c21:hover {
-  padding: 4px;
-}
-
-.c21 > svg {
   vertical-align: middle;
 }
 
@@ -20533,7 +20457,7 @@ exports[`DataTable should render new data when page changes 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c21"
+              class="c20 c17"
               type="button"
             >
               1
@@ -20547,7 +20471,7 @@ exports[`DataTable should render new data when page changes 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               2
@@ -20561,12 +20485,12 @@ exports[`DataTable should render new data when page changes 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -24614,7 +24538,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+              class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               type="button"
             >
               <svg
@@ -24640,7 +24564,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+              class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               type="button"
             >
               1
@@ -24655,7 +24579,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 hbyrhB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+              class="StyledButtonKind-sc-1vhfpnt-0 hbnxbA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               type="button"
             >
               2
@@ -24670,7 +24594,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 fVgacz StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 kcEAcc"
+              class="StyledButtonKind-sc-1vhfpnt-0 DfZNm StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               disabled=""
               type="button"
             >
@@ -24730,7 +24654,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -24741,25 +24665,25 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*="#"],
-.c23 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*="#"],
-.c23 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -24920,8 +24844,8 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -24979,8 +24903,8 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -25028,7 +24952,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border: 0;
 }
 
-.c22 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -25040,8 +24964,8 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -25060,31 +24984,31 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   flex: 1 0 auto;
 }
 
-.c22 > svg {
+.c21 > svg {
   vertical-align: bottom;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -25131,30 +25055,11 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
 }
 
 .c17 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c17 > svg {
-  vertical-align: middle;
-}
-
-.c21 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c21:hover {
-  padding: 4px;
-}
-
-.c21 > svg {
   vertical-align: middle;
 }
 
@@ -26864,7 +26769,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c21"
+              class="c20 c17"
               type="button"
             >
               1
@@ -26878,7 +26783,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
           >
             <button
               aria-label="Go to page 2"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               2
@@ -26892,12 +26797,12 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
           >
             <button
               aria-label="Go to next page"
-              class="c22 c21"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -26951,7 +26856,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   stroke: none;
 }
 
-.c22 {
+.c21 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -26962,25 +26867,25 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   stroke: #666666;
 }
 
-.c22 g {
+.c21 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c22 *:not([stroke])[fill="none"] {
+.c21 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c22 *[stroke*="#"],
-.c22 *[STROKE*="#"] {
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c22 *[fill-rule],
-.c22 *[FILL-RULE],
-.c22 *[fill*="#"],
-.c22 *[FILL*="#"] {
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -27123,8 +27028,8 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -27185,8 +27090,8 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -27246,8 +27151,8 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -27334,30 +27239,11 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 }
 
 .c16 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c16:hover {
-  padding: 4px;
 }
 
 .c16 > svg {
-  vertical-align: middle;
-}
-
-.c21 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c21 > svg {
   vertical-align: middle;
 }
 
@@ -28928,13 +28814,13 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="c20 c21"
+              class="c20 c16"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c22"
+                class="c21"
                 viewBox="0 0 24 24"
               >
                 <polyline

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -2136,7 +2136,7 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: none;
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -2147,25 +2147,25 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: #000000;
 }
 
-.c19 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c19 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c19 *[stroke*="#"],
-.c19 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c19 *[fill-rule],
-.c19 *[FILL-RULE],
-.c19 *[fill*="#"],
-.c19 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -2345,8 +2345,8 @@ exports[`List events should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -2404,8 +2404,8 @@ exports[`List events should apply pagination styling 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -2453,7 +2453,7 @@ exports[`List events should apply pagination styling 1`] = `
   border: 0;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2465,8 +2465,8 @@ exports[`List events should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -2485,59 +2485,40 @@ exports[`List events should apply pagination styling 1`] = `
   flex: 1 0 auto;
 }
 
-.c18 > svg {
+.c17 > svg {
   vertical-align: bottom;
 }
 
-.c18:hover {
+.c17:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c18:focus {
+.c17:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus > circle,
-.c18:focus > ellipse,
-.c18:focus > line,
-.c18:focus > path,
-.c18:focus > polygon,
-.c18:focus > polyline,
-.c18:focus > rect {
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus::-moz-focus-inner {
+.c17:focus::-moz-focus-inner {
   border: 0;
 }
 
 .c13 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c13 > svg {
-  vertical-align: middle;
-}
-
-.c17 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c17:hover {
-  padding: 4px;
-}
-
-.c17 > svg {
   vertical-align: middle;
 }
 
@@ -2954,7 +2935,7 @@ exports[`List events should apply pagination styling 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c16 c17"
+              class="c16 c13"
               type="button"
             >
               1
@@ -2968,7 +2949,7 @@ exports[`List events should apply pagination styling 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               2
@@ -2982,12 +2963,12 @@ exports[`List events should apply pagination styling 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c19"
+                class="c18"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -3041,7 +3022,7 @@ exports[`List events should paginate 1`] = `
   stroke: none;
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3052,25 +3033,25 @@ exports[`List events should paginate 1`] = `
   stroke: #000000;
 }
 
-.c19 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c19 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c19 *[stroke*="#"],
-.c19 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c19 *[fill-rule],
-.c19 *[FILL-RULE],
-.c19 *[fill*="#"],
-.c19 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -3248,8 +3229,8 @@ exports[`List events should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -3307,8 +3288,8 @@ exports[`List events should paginate 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -3356,7 +3337,7 @@ exports[`List events should paginate 1`] = `
   border: 0;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3368,8 +3349,8 @@ exports[`List events should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -3388,59 +3369,40 @@ exports[`List events should paginate 1`] = `
   flex: 1 0 auto;
 }
 
-.c18 > svg {
+.c17 > svg {
   vertical-align: bottom;
 }
 
-.c18:hover {
+.c17:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c18:focus {
+.c17:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus > circle,
-.c18:focus > ellipse,
-.c18:focus > line,
-.c18:focus > path,
-.c18:focus > polygon,
-.c18:focus > polyline,
-.c18:focus > rect {
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus::-moz-focus-inner {
+.c17:focus::-moz-focus-inner {
   border: 0;
 }
 
 .c13 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c13 > svg {
-  vertical-align: middle;
-}
-
-.c17 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c17:hover {
-  padding: 4px;
-}
-
-.c17 > svg {
   vertical-align: middle;
 }
 
@@ -3851,7 +3813,7 @@ exports[`List events should paginate 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c16 c17"
+              class="c16 c13"
               type="button"
             >
               1
@@ -3865,7 +3827,7 @@ exports[`List events should paginate 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               2
@@ -3879,12 +3841,12 @@ exports[`List events should paginate 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c19"
+                class="c18"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -3938,7 +3900,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   stroke: none;
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3949,25 +3911,25 @@ exports[`List events should render correct num items per page (step) 1`] = `
   stroke: #000000;
 }
 
-.c19 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c19 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c19 *[stroke*="#"],
-.c19 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c19 *[fill-rule],
-.c19 *[FILL-RULE],
-.c19 *[fill*="#"],
-.c19 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4145,8 +4107,8 @@ exports[`List events should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -4204,8 +4166,8 @@ exports[`List events should render correct num items per page (step) 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -4253,7 +4215,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border: 0;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4265,8 +4227,8 @@ exports[`List events should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -4285,59 +4247,40 @@ exports[`List events should render correct num items per page (step) 1`] = `
   flex: 1 0 auto;
 }
 
-.c18 > svg {
+.c17 > svg {
   vertical-align: bottom;
 }
 
-.c18:hover {
+.c17:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c18:focus {
+.c17:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus > circle,
-.c18:focus > ellipse,
-.c18:focus > line,
-.c18:focus > path,
-.c18:focus > polygon,
-.c18:focus > polyline,
-.c18:focus > rect {
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus::-moz-focus-inner {
+.c17:focus::-moz-focus-inner {
   border: 0;
 }
 
 .c13 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c13 > svg {
-  vertical-align: middle;
-}
-
-.c17 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c17:hover {
-  padding: 4px;
-}
-
-.c17 > svg {
   vertical-align: middle;
 }
 
@@ -4568,7 +4511,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c16 c17"
+              class="c16 c13"
               type="button"
             >
               1
@@ -4582,7 +4525,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               2
@@ -4596,7 +4539,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 3"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               3
@@ -4610,7 +4553,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 4"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               4
@@ -4624,7 +4567,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 5"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               5
@@ -4638,7 +4581,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 6"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               6
@@ -4652,7 +4595,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to page 7"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               7
@@ -4666,12 +4609,12 @@ exports[`List events should render correct num items per page (step) 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c19"
+                class="c18"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -4725,7 +4668,7 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: none;
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4736,25 +4679,25 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: #000000;
 }
 
-.c19 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c19 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c19 *[stroke*="#"],
-.c19 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c19 *[fill-rule],
-.c19 *[FILL-RULE],
-.c19 *[fill*="#"],
-.c19 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4932,8 +4875,8 @@ exports[`List events should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -4991,8 +4934,8 @@ exports[`List events should render new data when page changes 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -5040,7 +4983,7 @@ exports[`List events should render new data when page changes 1`] = `
   border: 0;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5052,8 +4995,8 @@ exports[`List events should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -5072,59 +5015,40 @@ exports[`List events should render new data when page changes 1`] = `
   flex: 1 0 auto;
 }
 
-.c18 > svg {
+.c17 > svg {
   vertical-align: bottom;
 }
 
-.c18:hover {
+.c17:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c18:focus {
+.c17:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus > circle,
-.c18:focus > ellipse,
-.c18:focus > line,
-.c18:focus > path,
-.c18:focus > polygon,
-.c18:focus > polyline,
-.c18:focus > rect {
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus::-moz-focus-inner {
+.c17:focus::-moz-focus-inner {
   border: 0;
 }
 
 .c13 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c13 > svg {
-  vertical-align: middle;
-}
-
-.c17 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c17:hover {
-  padding: 4px;
-}
-
-.c17 > svg {
   vertical-align: middle;
 }
 
@@ -5535,7 +5459,7 @@ exports[`List events should render new data when page changes 1`] = `
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c16 c17"
+              class="c16 c13"
               type="button"
             >
               1
@@ -5549,7 +5473,7 @@ exports[`List events should render new data when page changes 1`] = `
           >
             <button
               aria-label="Go to page 2"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               2
@@ -5563,12 +5487,12 @@ exports[`List events should render new data when page changes 1`] = `
           >
             <button
               aria-label="Go to next page"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c19"
+                class="c18"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -5841,7 +5765,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+              class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               type="button"
             >
               <svg
@@ -5867,7 +5791,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+              class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               type="button"
             >
               1
@@ -5882,7 +5806,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 hbyrhB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+              class="StyledButtonKind-sc-1vhfpnt-0 hbnxbA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               type="button"
             >
               2
@@ -5897,7 +5821,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 fVgacz StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 kcEAcc"
+              class="StyledButtonKind-sc-1vhfpnt-0 DfZNm StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
               disabled=""
               type="button"
             >
@@ -5957,7 +5881,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   stroke: none;
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5968,25 +5892,25 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   stroke: #000000;
 }
 
-.c19 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c19 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c19 *[stroke*="#"],
-.c19 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c19 *[fill-rule],
-.c19 *[FILL-RULE],
-.c19 *[fill*="#"],
-.c19 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6164,8 +6088,8 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -6223,8 +6147,8 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -6272,7 +6196,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   border: 0;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6284,8 +6208,8 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -6304,59 +6228,40 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   flex: 1 0 auto;
 }
 
-.c18 > svg {
+.c17 > svg {
   vertical-align: bottom;
 }
 
-.c18:hover {
+.c17:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c18:focus {
+.c17:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus > circle,
-.c18:focus > ellipse,
-.c18:focus > line,
-.c18:focus > path,
-.c18:focus > polygon,
-.c18:focus > polyline,
-.c18:focus > rect {
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus::-moz-focus-inner {
+.c17:focus::-moz-focus-inner {
   border: 0;
 }
 
 .c13 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c13 > svg {
-  vertical-align: middle;
-}
-
-.c17 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c17:hover {
-  padding: 4px;
-}
-
-.c17 > svg {
   vertical-align: middle;
 }
 
@@ -6767,7 +6672,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c16 c17"
+              class="c16 c13"
               type="button"
             >
               1
@@ -6781,7 +6686,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           >
             <button
               aria-label="Go to page 2"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               2
@@ -6795,12 +6700,12 @@ exports[`List events should show correct item index when "show" is a number 1`] 
           >
             <button
               aria-label="Go to next page"
-              class="c18 c17"
+              class="c17 c13"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c19"
+                class="c18"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -6854,7 +6759,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6865,25 +6770,25 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   stroke: #666666;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill="none"] {
+.c17 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*="#"],
-.c18 *[STROKE*="#"] {
+.c17 *[stroke*="#"],
+.c17 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*="#"],
-.c18 *[FILL*="#"] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*="#"],
+.c17 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7043,8 +6948,8 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -7105,8 +7010,8 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -7166,8 +7071,8 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -7212,30 +7117,11 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 }
 
 .c12 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c12:hover {
-  padding: 4px;
 }
 
 .c12 > svg {
-  vertical-align: middle;
-}
-
-.c17 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c17 > svg {
   vertical-align: middle;
 }
 
@@ -7641,13 +7527,13 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="c16 c17"
+              class="c16 c12"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c18"
+                class="c17"
                 viewBox="0 0 24 24"
               >
                 <polyline

--- a/src/js/components/Pagination/PageControl.js
+++ b/src/js/components/Pagination/PageControl.js
@@ -7,20 +7,26 @@ import {
   StyledSeparator,
 } from './StyledPageControl';
 
-export const PageControl = ({ control, separator, size, ...rest }) => {
+export const PageControl = ({
+  control,
+  separator,
+  size: sizeProp,
+  ...rest
+}) => {
   const theme = useContext(ThemeContext);
+  const size = sizeProp || 'medium';
 
   return (
-    <StyledContainer as="li" controlSize={size}>
+    <StyledContainer as="li" size={size}>
       {separator ? (
-        <StyledSeparator controlSize={size}>&#8230;</StyledSeparator>
+        <StyledSeparator size={size}>&#8230;</StyledSeparator>
       ) : (
         <StyledPaginationButton
           a11yTitle={`Go to page ${control}`}
           fill
           kind={theme.pagination.button}
           label={control}
-          controlSize={size}
+          size={size}
           {...rest}
         />
       )}

--- a/src/js/components/Pagination/README.md
+++ b/src/js/components/Pagination/README.md
@@ -197,44 +197,68 @@ nav
 ```
 ## Theme
   
-**pagination.button.active.background.color**
+**pagination.button**
 
-Background color when the button is active. Expects `string | { dark: string, light: string }`.
-
-Defaults to
-
-```
-active-background
-```
-
-**pagination.button.color**
-
-The color of the text label. Expects `string | { dark: string, light: string }`.
+Any valid Button theming to apply on the pagination buttons. Expects `object`.
 
 Defaults to
 
 ```
-text-strong
-```
-
-**pagination.button.hover.background.color**
-
-Background color of the button when hovered. Expects `string | { dark: string, light: string }`.
-
-Defaults to
-
-```
-background-contrast
-```
-
-**pagination.button.hover.color**
-
-The color of the text label when hovered. Expects `string | { dark: string, light: string }`.
-
-Defaults to
-
-```
-undefined
+{
+      active: {
+        background: {
+          color: 'active-background',
+        },
+      },
+      color: 'text-strong',
+      hover: {
+        background: {
+          color: 'background-contrast',
+        },
+        color: undefined,
+      },
+      size: {
+        small: {
+          border: {
+            radius: 3px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 14px,
+          height: 30px,
+          width: 30px,
+        },
+        medium: {
+          border: {
+            radius: 4px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 18px,
+          height: 36px,
+          width: 36px,
+        },
+        large: {
+          border: {
+            radius: 6px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 22px,
+          height: 48px,
+          width: 48px,
+        },
+      },
+    }
 ```
 
 **pagination.container**
@@ -257,189 +281,6 @@ Defaults to
 
 ```
 undefined
-```
-
-**pagination.button.size.small.border.radius**
-
-Rounding of the corners for each button. Expects `string`.
-
-Defaults to
-
-```
-3px
-```
-
-**pagination.button.size.small.border.width**
-
-Border thickness for each button. Expects `string`.
-
-Defaults to
-
-```
-2px
-```
-
-**pagination.button.size.small.font.size**
-
-The font size of each button's label. Expects `string`.
-
-Defaults to
-
-```
-14px
-```
-
-**pagination.button.size.small.font.height**
-
-The line-height of each button's label. Expects `string`.
-
-Defaults to
-
-```
-20px
-```
-
-**pagination.button.size.small.height**
-
-The height for each button. Expects `string`.
-
-Defaults to
-
-```
-30px
-```
-
-**pagination.button.size.small.width**
-
-The minimum width for each button. 
-    Width will scale up fitting the button's label. Expects `string`.
-
-Defaults to
-
-```
-30px
-```
-
-**pagination.button.size.medium.border.radius**
-
-Rounding of the corners for each button. Expects `string`.
-
-Defaults to
-
-```
-4px
-```
-
-**pagination.button.size.medium.border.width**
-
-Border thickness for each button. Expects `string`.
-
-Defaults to
-
-```
-2px
-```
-
-**pagination.button.size.medium.font.size**
-
-The font size of each button's label. Expects `string`.
-
-Defaults to
-
-```
-18px
-```
-
-**pagination.button.size.medium.font.height**
-
-The line-height of each button's label. Expects `string`.
-
-Defaults to
-
-```
-24px
-```
-
-**pagination.button.size.medium.height**
-
-The height for each button. Expects `string`.
-
-Defaults to
-
-```
-36px
-```
-
-**pagination.button.size.medium.width**
-
-The minimum width for each button. 
-    Width will scale up fitting the button's label. Expects `string`.
-
-Defaults to
-
-```
-36px
-```
-
-**pagination.button.size.large.border.radius**
-
-Rounding of the corners for each button. Expects `string`.
-
-Defaults to
-
-```
-4px
-```
-
-**pagination.button.size.large.border.width**
-
-Border thickness for each button. Expects `string`.
-
-Defaults to
-
-```
-6px
-```
-
-**pagination.button.size.large.font.size**
-
-The font size of each button's label. Expects `string`.
-
-Defaults to
-
-```
-22px
-```
-
-**pagination.button.size.large.font.height**
-
-The line-height of each button's label. Expects `string`.
-
-Defaults to
-
-```
-28px
-```
-
-**pagination.button.size.large.height**
-
-The height for each button. Expects `string`.
-
-Defaults to
-
-```
-48px
-```
-
-**pagination.button.size.large.width**
-
-The minimum width for each button. 
-    Width will scale up fitting the button's label. Expects `string`.
-
-Defaults to
-
-```
-48px
 ```
 
 **pagination.controls.align**

--- a/src/js/components/Pagination/README.md
+++ b/src/js/components/Pagination/README.md
@@ -259,29 +259,9 @@ Defaults to
 undefined
 ```
 
-**pagination.control.extend**
+**pagination.button.size.small.border.radius**
 
-Any additional style for each control. Expects `string | (props) => {}`.
-
-Defaults to
-
-```
-undefined
-```
-
-**pagination.control.pad**
-
-Padding around each control's label. Expects `string | object`.
-
-Defaults to
-
-```
-4px
-```
-
-**pagination.control.size.small.border.radius**
-
-Rounding of the corners for each control. Expects `string`.
+Rounding of the corners for each button. Expects `string`.
 
 Defaults to
 
@@ -289,9 +269,9 @@ Defaults to
 3px
 ```
 
-**pagination.control.size.small.border.width**
+**pagination.button.size.small.border.width**
 
-Border thickness for each control. Expects `string`.
+Border thickness for each button. Expects `string`.
 
 Defaults to
 
@@ -299,9 +279,9 @@ Defaults to
 2px
 ```
 
-**pagination.control.size.small.font.size**
+**pagination.button.size.small.font.size**
 
-The font size of each control's label. Expects `string`.
+The font size of each button's label. Expects `string`.
 
 Defaults to
 
@@ -309,9 +289,9 @@ Defaults to
 14px
 ```
 
-**pagination.control.size.small.font.height**
+**pagination.button.size.small.font.height**
 
-The line-height of each control's label. Expects `string`.
+The line-height of each button's label. Expects `string`.
 
 Defaults to
 
@@ -319,20 +299,9 @@ Defaults to
 20px
 ```
 
-**pagination.control.size.small.height**
+**pagination.button.size.small.height**
 
-The height for each control. Expects `string`.
-
-Defaults to
-
-```
-30px
-```
-
-**pagination.control.size.small.width**
-
-The minimum width for each control. 
-    Width will scale up fitting the control's label. Expects `string`.
+The height for each button. Expects `string`.
 
 Defaults to
 
@@ -340,9 +309,20 @@ Defaults to
 30px
 ```
 
-**pagination.control.size.medium.border.radius**
+**pagination.button.size.small.width**
 
-Rounding of the corners for each control. Expects `string`.
+The minimum width for each button. 
+    Width will scale up fitting the button's label. Expects `string`.
+
+Defaults to
+
+```
+30px
+```
+
+**pagination.button.size.medium.border.radius**
+
+Rounding of the corners for each button. Expects `string`.
 
 Defaults to
 
@@ -350,9 +330,9 @@ Defaults to
 4px
 ```
 
-**pagination.control.size.medium.border.width**
+**pagination.button.size.medium.border.width**
 
-Border thickness for each control. Expects `string`.
+Border thickness for each button. Expects `string`.
 
 Defaults to
 
@@ -360,9 +340,9 @@ Defaults to
 2px
 ```
 
-**pagination.control.size.medium.font.size**
+**pagination.button.size.medium.font.size**
 
-The font size of each control's label. Expects `string`.
+The font size of each button's label. Expects `string`.
 
 Defaults to
 
@@ -370,9 +350,9 @@ Defaults to
 18px
 ```
 
-**pagination.control.size.medium.font.height**
+**pagination.button.size.medium.font.height**
 
-The line-height of each control's label. Expects `string`.
+The line-height of each button's label. Expects `string`.
 
 Defaults to
 
@@ -380,20 +360,9 @@ Defaults to
 24px
 ```
 
-**pagination.control.size.medium.height**
+**pagination.button.size.medium.height**
 
-The height for each control. Expects `string`.
-
-Defaults to
-
-```
-36px
-```
-
-**pagination.control.size.medium.width**
-
-The minimum width for each control. 
-    Width will scale up fitting the control's label. Expects `string`.
+The height for each button. Expects `string`.
 
 Defaults to
 
@@ -401,9 +370,20 @@ Defaults to
 36px
 ```
 
-**pagination.control.size.large.border.radius**
+**pagination.button.size.medium.width**
 
-Rounding of the corners for each control. Expects `string`.
+The minimum width for each button. 
+    Width will scale up fitting the button's label. Expects `string`.
+
+Defaults to
+
+```
+36px
+```
+
+**pagination.button.size.large.border.radius**
+
+Rounding of the corners for each button. Expects `string`.
 
 Defaults to
 
@@ -411,9 +391,9 @@ Defaults to
 4px
 ```
 
-**pagination.control.size.large.border.width**
+**pagination.button.size.large.border.width**
 
-Border thickness for each control. Expects `string`.
+Border thickness for each button. Expects `string`.
 
 Defaults to
 
@@ -421,9 +401,9 @@ Defaults to
 6px
 ```
 
-**pagination.control.size.large.font.size**
+**pagination.button.size.large.font.size**
 
-The font size of each control's label. Expects `string`.
+The font size of each button's label. Expects `string`.
 
 Defaults to
 
@@ -431,9 +411,9 @@ Defaults to
 22px
 ```
 
-**pagination.control.size.large.font.height**
+**pagination.button.size.large.font.height**
 
-The line-height of each control's label. Expects `string`.
+The line-height of each button's label. Expects `string`.
 
 Defaults to
 
@@ -441,9 +421,9 @@ Defaults to
 28px
 ```
 
-**pagination.control.size.large.height**
+**pagination.button.size.large.height**
 
-The height for each control. Expects `string`.
+The height for each button. Expects `string`.
 
 Defaults to
 
@@ -451,10 +431,10 @@ Defaults to
 48px
 ```
 
-**pagination.control.size.large.width**
+**pagination.button.size.large.width**
 
-The minimum width for each control. 
-    Width will scale up fitting the control's label. Expects `string`.
+The minimum width for each button. 
+    Width will scale up fitting the button's label. Expects `string`.
 
 Defaults to
 

--- a/src/js/components/Pagination/StyledPageControl.js
+++ b/src/js/components/Pagination/StyledPageControl.js
@@ -3,54 +3,17 @@ import styled from 'styled-components';
 import { Button } from '../Button';
 import { Text } from '../Text';
 
-const BUTTON_STATES = ['normal', 'active', 'disabled', 'hover'];
-
-// Assemble button theme object for each button state
-const buildButtonStyle = (buttonTheme, kind) => {
-  const style = buttonTheme[kind];
-  BUTTON_STATES.forEach(state => {
-    if (state !== 'normal' && buttonTheme[state])
-      style[state] = buttonTheme[state][kind];
-  });
-  return style;
-};
-
-// Allow padding to flex when border is present. Calculated adjusted
-// padding needed (if any) for each button state.
-const calcAdjustedPadding = (buttonStyle, pad) => {
-  const adjustedPadding = {};
-
-  BUTTON_STATES.forEach(state => {
-    const border =
-      (buttonStyle[state] &&
-        buttonStyle[state].border &&
-        buttonStyle[state].border.width) ||
-      (buttonStyle.border && buttonStyle.border.width) ||
-      '0px';
-
-    const adjustedPad = `${Math.max(
-      pad.replace('px', '') - border.replace('px', ''),
-      0,
-    )}px`;
-    adjustedPadding[state] = { pad: undefined };
-    adjustedPadding[state].pad = adjustedPad;
-  });
-  return adjustedPadding;
-};
-
 const sizeStyle = props => {
   const style =
-    props.theme.pagination.control &&
-    props.theme.pagination.control.size &&
-    props.theme.pagination.control.size[props.controlSize || 'medium'];
+    props.theme.pagination.button &&
+    props.theme.pagination.button.size &&
+    props.theme.pagination.button.size[props.size || 'medium'];
 
   return style
     ? {
         content: {
           fontSize: style.font && style.font.size,
           lineHeight: style.font && style.font.height,
-          borderRadius: style.border && style.border.radius,
-          borderWidth: style.border && style.border.width,
         },
         container: {
           height: style.height,
@@ -61,29 +24,6 @@ const sizeStyle = props => {
 };
 
 export const StyledPaginationButton = styled(Button)`
-  ${props => {
-    const buttonStyle =
-      typeof props.kind === 'string'
-        ? buildButtonStyle(props.theme.button, props.kind)
-        : props.kind;
-    const adjustedPadding = calcAdjustedPadding(
-      buttonStyle,
-      props.theme.pagination.control.pad,
-    );
-    let buttonState = 'normal';
-    if (props.active) buttonState = 'active';
-    else if (props.disabled) buttonState = 'disabled';
-
-    return `
-      padding: ${adjustedPadding[buttonState].pad};
-      ${
-        buttonState === 'disabled'
-          ? ''
-          : `:hover { padding: ${adjustedPadding.hover.pad}; }`
-      }
-    `;
-  }}
-
   > svg {
     vertical-align: middle;
   }
@@ -102,6 +42,10 @@ export const StyledContainer = styled.div`
 
 export const StyledSeparator = styled(Text)`
   font-weight: bold;
-  ${props => `font-size: ${sizeStyle(props).content.fontSize}`};
-  ${props => `line-height: ${sizeStyle(props).content.lineHeight}`};
+  ${props =>
+    `font-size: ${sizeStyle(props).content &&
+      sizeStyle(props).content.fontSize}`};
+  ${props =>
+    `line-height: ${sizeStyle(props).content &&
+      sizeStyle(props).content.lineHeight}`};
 `;

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -121,8 +121,8 @@ exports[`Pagination should allow user to control page via state with page +
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -182,8 +182,8 @@ exports[`Pagination should allow user to control page via state with page +
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -236,15 +236,8 @@ exports[`Pagination should allow user to control page via state with page +
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
@@ -692,7 +685,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   border: 0;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -728,60 +721,36 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   flex: 1 0 auto;
 }
 
-.c11 > svg {
+.c10 > svg {
   vertical-align: bottom;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
-}
-
-.c6 {
-  padding: 2px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c10 {
-  padding: 2px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c10:hover {
-  padding: 2px;
-}
-
-.c10 > svg {
   vertical-align: middle;
 }
 
@@ -799,14 +768,12 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   -ms-flex-pack: center;
   justify-content: center;
   max-width: 100%;
-  height: 36px;
-  min-width: 36px;
 }
 
-.c13 {
+.c12 {
   font-weight: bold;
-  font-size: 18px;
-  line-height: 24px;
+  font-size: undefined;
+  line-height: undefined;
 }
 
 @media only screen and (max-width:768px) {
@@ -874,7 +841,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c10"
+            class="c9 c6"
             type="button"
           >
             1
@@ -888,7 +855,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             2
@@ -902,7 +869,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             3
@@ -916,7 +883,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
         >
           <button
             aria-label="Go to page 4"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             4
@@ -930,7 +897,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
         >
           <button
             aria-label="Go to page 5"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             5
@@ -943,7 +910,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
           class="c4"
         >
           <span
-            class="c12 c13"
+            class="c11 c12"
           >
             …
           </span>
@@ -956,7 +923,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             24
@@ -970,7 +937,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
         >
           <button
             aria-label="Go to next page"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             <svg
@@ -1028,7 +995,7 @@ exports[`Pagination should apply custom theme 1`] = `
   stroke: none;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1039,25 +1006,25 @@ exports[`Pagination should apply custom theme 1`] = `
   stroke: #000000;
 }
 
-.c15 g {
+.c14 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c15 *:not([stroke])[fill="none"] {
+.c14 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c15 *[stroke*="#"],
-.c15 *[STROKE*="#"] {
+.c14 *[stroke*="#"],
+.c14 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c15 *[fill-rule],
-.c15 *[FILL-RULE],
-.c15 *[fill*="#"],
-.c15 *[FILL*="#"] {
+.c14 *[fill-rule],
+.c14 *[FILL-RULE],
+.c14 *[fill*="#"],
+.c14 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1145,8 +1112,8 @@ exports[`Pagination should apply custom theme 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -1204,8 +1171,8 @@ exports[`Pagination should apply custom theme 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -1253,7 +1220,7 @@ exports[`Pagination should apply custom theme 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1265,8 +1232,8 @@ exports[`Pagination should apply custom theme 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -1285,64 +1252,45 @@ exports[`Pagination should apply custom theme 1`] = `
   flex: 1 0 auto;
 }
 
-.c12 > svg {
+.c11 > svg {
   vertical-align: bottom;
 }
 
-.c12:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
 }
 
 .c7 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c7 > svg {
-  vertical-align: middle;
-}
-
-.c11 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c11:hover {
-  padding: 4px;
-}
-
-.c11 > svg {
   vertical-align: middle;
 }
 
@@ -1364,7 +1312,7 @@ exports[`Pagination should apply custom theme 1`] = `
   min-width: 36px;
 }
 
-.c14 {
+.c13 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
@@ -1439,7 +1387,7 @@ exports[`Pagination should apply custom theme 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c10 c11"
+            class="c10 c7"
             type="button"
           >
             1
@@ -1453,7 +1401,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c12 c11"
+            class="c11 c7"
             type="button"
           >
             2
@@ -1467,7 +1415,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c12 c11"
+            class="c11 c7"
             type="button"
           >
             3
@@ -1481,7 +1429,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c12 c11"
+            class="c11 c7"
             type="button"
           >
             4
@@ -1495,7 +1443,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c12 c11"
+            class="c11 c7"
             type="button"
           >
             5
@@ -1508,7 +1456,7 @@ exports[`Pagination should apply custom theme 1`] = `
           class="c5"
         >
           <span
-            class="c13 c14"
+            class="c12 c13"
           >
             …
           </span>
@@ -1521,7 +1469,7 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to page 24"
-            class="c12 c11"
+            class="c11 c7"
             type="button"
           >
             24
@@ -1535,12 +1483,12 @@ exports[`Pagination should apply custom theme 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c12 c11"
+            class="c11 c7"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c15"
+              class="c14"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -1593,7 +1541,7 @@ exports[`Pagination should apply size 1`] = `
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1604,25 +1552,25 @@ exports[`Pagination should apply size 1`] = `
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1710,8 +1658,8 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -1769,8 +1717,8 @@ exports[`Pagination should apply size 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -1818,7 +1766,7 @@ exports[`Pagination should apply size 1`] = `
   border: 0;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1830,8 +1778,8 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -1850,120 +1798,433 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 > svg {
+.c10 > svg {
   vertical-align: bottom;
 }
 
-.c11:hover {
+.c10:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 4px;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c15 > svg {
+  vertical-align: bottom;
+}
+
+.c15:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c15:focus > circle,
+.c15:focus > ellipse,
+.c15:focus > line,
+.c15:focus > path,
+.c15:focus > polygon,
+.c15:focus > polyline,
+.c15:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c15:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c17 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 4px;
+  font-size: 14px;
+  line-height: 20px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c17 > svg {
+  vertical-align: bottom;
+}
+
+.c17:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c17:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c18 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 4px;
+  font-size: 14px;
+  line-height: 20px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c18 > svg {
+  vertical-align: bottom;
+}
+
+.c18:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c18:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c18:focus > circle,
+.c18:focus > ellipse,
+.c18:focus > line,
+.c18:focus > path,
+.c18:focus > polygon,
+.c18:focus > polyline,
+.c18:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c18:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c22 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 4px;
+  font-size: 22px;
+  line-height: 28px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c22 > svg {
+  vertical-align: bottom;
+}
+
+.c22:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c22:focus > circle,
+.c22:focus > ellipse,
+.c22:focus > line,
+.c22:focus > path,
+.c22:focus > polygon,
+.c22:focus > polyline,
+.c22:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c22:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c24 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 4px;
+  font-size: 22px;
+  line-height: 28px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c24 > svg {
+  vertical-align: bottom;
+}
+
+.c24:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c24:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c24:focus > circle,
+.c24:focus > ellipse,
+.c24:focus > line,
+.c24:focus > path,
+.c24:focus > polygon,
+.c24:focus > polyline,
+.c24:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c24:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c25 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 4px;
+  font-size: 22px;
+  line-height: 28px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c25 > svg {
+  vertical-align: bottom;
+}
+
+.c25:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c25:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c25:focus > circle,
+.c25:focus > ellipse,
+.c25:focus > line,
+.c25:focus > path,
+.c25:focus > polygon,
+.c25:focus > polyline,
+.c25:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c25:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
   font-size: 18px;
   line-height: 24px;
 }
 
+.c19 {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c26 {
+  font-size: 22px;
+  line-height: 28px;
+}
+
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
   vertical-align: middle;
 }
 
-.c10 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c10:hover {
-  padding: 4px;
-}
-
-.c10 > svg {
-  vertical-align: middle;
-}
-
 .c16 {
-  padding: 4px;
   font-size: 14px;
   line-height: 20px;
-  border-radius: 3px;
-  border-width: 2px;
 }
 
 .c16 > svg {
   vertical-align: middle;
 }
 
-.c17 {
-  padding: 4px;
-  font-size: 14px;
-  line-height: 20px;
-  border-radius: 3px;
-  border-width: 2px;
-}
-
-.c17:hover {
-  padding: 4px;
-}
-
-.c17 > svg {
-  vertical-align: middle;
-}
-
-.c20 {
-  padding: 4px;
+.c23 {
   font-size: 22px;
   line-height: 28px;
-  border-radius: 6px;
-  border-width: 2px;
 }
 
-.c20 > svg {
-  vertical-align: middle;
-}
-
-.c21 {
-  padding: 4px;
-  font-size: 22px;
-  line-height: 28px;
-  border-radius: 6px;
-  border-width: 2px;
-}
-
-.c21:hover {
-  padding: 4px;
-}
-
-.c21 > svg {
+.c23 > svg {
   vertical-align: middle;
 }
 
@@ -1985,7 +2246,7 @@ exports[`Pagination should apply size 1`] = `
   min-width: 36px;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2003,7 +2264,7 @@ exports[`Pagination should apply size 1`] = `
   min-width: 30px;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2021,19 +2282,19 @@ exports[`Pagination should apply size 1`] = `
   min-width: 48px;
 }
 
-.c13 {
+.c12 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-weight: bold;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c22 {
+.c27 {
   font-weight: bold;
   font-size: 22px;
   line-height: 28px;
@@ -2104,7 +2365,7 @@ exports[`Pagination should apply size 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c10"
+            class="c9 c6"
             type="button"
           >
             1
@@ -2118,7 +2379,7 @@ exports[`Pagination should apply size 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             2
@@ -2132,7 +2393,7 @@ exports[`Pagination should apply size 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             3
@@ -2146,7 +2407,7 @@ exports[`Pagination should apply size 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             4
@@ -2160,7 +2421,7 @@ exports[`Pagination should apply size 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             5
@@ -2173,7 +2434,7 @@ exports[`Pagination should apply size 1`] = `
           class="c4"
         >
           <span
-            class="c12 c13"
+            class="c11 c12"
           >
             …
           </span>
@@ -2186,7 +2447,7 @@ exports[`Pagination should apply size 1`] = `
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             24
@@ -2200,12 +2461,12 @@ exports[`Pagination should apply size 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -2231,12 +2492,12 @@ exports[`Pagination should apply size 1`] = `
         class="c3"
       >
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c16"
+            class="c15 c16"
             disabled=""
             type="button"
           >
@@ -2259,12 +2520,12 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c17"
+            class="c17 c16"
             type="button"
           >
             1
@@ -2274,11 +2535,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c17"
+            class="c18 c16"
             type="button"
           >
             2
@@ -2288,11 +2549,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c17"
+            class="c18 c16"
             type="button"
           >
             3
@@ -2302,11 +2563,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 4"
-            class="c11 c17"
+            class="c18 c16"
             type="button"
           >
             4
@@ -2316,11 +2577,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 5"
-            class="c11 c17"
+            class="c18 c16"
             type="button"
           >
             5
@@ -2330,10 +2591,10 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <span
-            class="c12 c18"
+            class="c19 c20"
           >
             …
           </span>
@@ -2342,11 +2603,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c17"
+            class="c18 c16"
             type="button"
           >
             24
@@ -2356,16 +2617,16 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to next page"
-            class="c11 c17"
+            class="c18 c16"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -2391,12 +2652,12 @@ exports[`Pagination should apply size 1`] = `
         class="c3"
       >
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c20"
+            class="c22 c23"
             disabled=""
             type="button"
           >
@@ -2419,12 +2680,12 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c21"
+            class="c24 c23"
             type="button"
           >
             1
@@ -2434,11 +2695,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c21"
+            class="c25 c23"
             type="button"
           >
             2
@@ -2448,11 +2709,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c21"
+            class="c25 c23"
             type="button"
           >
             3
@@ -2462,11 +2723,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-label="Go to page 4"
-            class="c11 c21"
+            class="c25 c23"
             type="button"
           >
             4
@@ -2476,11 +2737,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-label="Go to page 5"
-            class="c11 c21"
+            class="c25 c23"
             type="button"
           >
             5
@@ -2490,10 +2751,10 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <span
-            class="c12 c22"
+            class="c26 c27"
           >
             …
           </span>
@@ -2502,11 +2763,11 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c21"
+            class="c25 c23"
             type="button"
           >
             24
@@ -2516,16 +2777,16 @@ exports[`Pagination should apply size 1`] = `
           class="c8"
         />
         <li
-          class="c19"
+          class="c21"
         >
           <button
             aria-label="Go to next page"
-            class="c11 c21"
+            class="c25 c23"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -2578,7 +2839,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -2589,25 +2850,25 @@ exports[`Pagination should disable next button if on last page 1`] = `
   stroke: #666666;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -2695,8 +2956,8 @@ exports[`Pagination should disable next button if on last page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -2757,8 +3018,8 @@ exports[`Pagination should disable next button if on last page 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -2818,8 +3079,8 @@ exports[`Pagination should disable next button if on last page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -2869,30 +3130,11 @@ exports[`Pagination should disable next button if on last page 1`] = `
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c13 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c13 > svg {
   vertical-align: middle;
 }
 
@@ -3080,13 +3322,13 @@ exports[`Pagination should disable next button if on last page 1`] = `
           <button
             aria-disabled="true"
             aria-label="Go to next page"
-            class="c12 c13"
+            class="c12 c6"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -3223,8 +3465,8 @@ exports[`Pagination should disable previous and next controls when numberItems
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -3282,8 +3524,8 @@ exports[`Pagination should disable previous and next controls when numberItems
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -3332,30 +3574,11 @@ exports[`Pagination should disable previous and next controls when numberItems
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c10 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c10:hover {
-  padding: 4px;
-}
-
-.c10 > svg {
   vertical-align: middle;
 }
 
@@ -3442,7 +3665,7 @@ exports[`Pagination should disable previous and next controls when numberItems
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c10"
+            class="c9 c6"
             type="button"
           >
             1
@@ -3600,8 +3823,8 @@ exports[`Pagination should disable previous and next controls when numberItems
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -3646,11 +3869,8 @@ exports[`Pagination should disable previous and next controls when numberItems
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
@@ -3882,8 +4102,8 @@ exports[`Pagination should disable previous and next controls when numberItems
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -3941,8 +4161,8 @@ exports[`Pagination should disable previous and next controls when numberItems
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -3991,30 +4211,11 @@ exports[`Pagination should disable previous and next controls when numberItems
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c10 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c10:hover {
-  padding: 4px;
-}
-
-.c10 > svg {
   vertical-align: middle;
 }
 
@@ -4101,7 +4302,7 @@ exports[`Pagination should disable previous and next controls when numberItems
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c10"
+            class="c9 c6"
             type="button"
           >
             1
@@ -4175,7 +4376,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4186,25 +4387,25 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4292,8 +4493,8 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -4351,8 +4552,8 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -4400,7 +4601,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   border: 0;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4412,8 +4613,8 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -4432,64 +4633,45 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 > svg {
+.c10 > svg {
   vertical-align: bottom;
 }
 
-.c11:hover {
+.c10:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c10 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c10:hover {
-  padding: 4px;
-}
-
-.c10 > svg {
   vertical-align: middle;
 }
 
@@ -4511,7 +4693,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   min-width: 36px;
 }
 
-.c13 {
+.c12 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
@@ -4582,7 +4764,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c10"
+            class="c9 c6"
             type="button"
           >
             1
@@ -4596,7 +4778,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             2
@@ -4610,7 +4792,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             3
@@ -4624,7 +4806,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 4"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             4
@@ -4638,7 +4820,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 5"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             5
@@ -4651,7 +4833,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
           class="c4"
         >
           <span
-            class="c12 c13"
+            class="c11 c12"
           >
             …
           </span>
@@ -4664,7 +4846,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             24
@@ -4678,12 +4860,12 @@ exports[`Pagination should disable previous button if on first page 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -4822,8 +5004,8 @@ exports[`Pagination should display next page of results when "next" is
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -4883,8 +5065,8 @@ exports[`Pagination should display next page of results when "next" is
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -4937,15 +5119,8 @@ exports[`Pagination should display next page of results when "next" is
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
@@ -5178,7 +5353,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             <svg
@@ -5204,7 +5379,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             1
@@ -5219,7 +5394,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 hbyrhB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 hbnxbA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             2
@@ -5233,7 +5408,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             3
@@ -5247,7 +5422,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             4
@@ -5261,7 +5436,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             5
@@ -5287,7 +5462,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             24
@@ -5301,7 +5476,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             <svg
@@ -5445,8 +5620,8 @@ exports[`Pagination should display page 'n' of results when "page n" is
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -5506,8 +5681,8 @@ exports[`Pagination should display page 'n' of results when "page n" is
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -5560,15 +5735,8 @@ exports[`Pagination should display page 'n' of results when "page n" is
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
@@ -5900,8 +6068,8 @@ exports[`Pagination should display previous page of results when "previous" is
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -5962,8 +6130,8 @@ exports[`Pagination should display previous page of results when "previous" is
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -6017,15 +6185,8 @@ exports[`Pagination should display previous page of results when "previous" is
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
@@ -6258,7 +6419,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             <svg
@@ -6284,7 +6445,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             1
@@ -6299,7 +6460,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 hbyrhB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 hbnxbA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             2
@@ -6313,7 +6474,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             3
@@ -6327,7 +6488,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             4
@@ -6341,7 +6502,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             5
@@ -6367,7 +6528,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             24
@@ -6381,7 +6542,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eRddyj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 cQMJwu"
+            class="StyledButtonKind-sc-1vhfpnt-0 eFsKTS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fgRkGN"
             type="button"
           >
             <svg
@@ -6440,7 +6601,7 @@ exports[`Pagination should display the correct last page based on items length
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6451,25 +6612,25 @@ exports[`Pagination should display the correct last page based on items length
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6557,8 +6718,8 @@ exports[`Pagination should display the correct last page based on items length
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -6616,8 +6777,8 @@ exports[`Pagination should display the correct last page based on items length
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -6665,7 +6826,7 @@ exports[`Pagination should display the correct last page based on items length
   border: 0;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6677,8 +6838,8 @@ exports[`Pagination should display the correct last page based on items length
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -6697,64 +6858,45 @@ exports[`Pagination should display the correct last page based on items length
   flex: 1 0 auto;
 }
 
-.c11 > svg {
+.c10 > svg {
   vertical-align: bottom;
 }
 
-.c11:hover {
+.c10:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c10 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c10:hover {
-  padding: 4px;
-}
-
-.c10 > svg {
   vertical-align: middle;
 }
 
@@ -6776,7 +6918,7 @@ exports[`Pagination should display the correct last page based on items length
   min-width: 36px;
 }
 
-.c13 {
+.c12 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
@@ -6847,7 +6989,7 @@ exports[`Pagination should display the correct last page based on items length
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c10"
+            class="c9 c6"
             type="button"
           >
             1
@@ -6861,7 +7003,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             2
@@ -6875,7 +7017,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             3
@@ -6889,7 +7031,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 4"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             4
@@ -6903,7 +7045,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 5"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             5
@@ -6916,7 +7058,7 @@ exports[`Pagination should display the correct last page based on items length
           class="c4"
         >
           <span
-            class="c12 c13"
+            class="c11 c12"
           >
             …
           </span>
@@ -6929,7 +7071,7 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             24
@@ -6943,12 +7085,12 @@ exports[`Pagination should display the correct last page based on items length
         >
           <button
             aria-label="Go to next page"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -7084,8 +7226,8 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -7146,8 +7288,8 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -7201,15 +7343,8 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
@@ -7594,8 +7729,8 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -7656,8 +7791,8 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -7711,15 +7846,8 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
@@ -8062,8 +8190,8 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -8124,8 +8252,8 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -8179,15 +8307,8 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
@@ -8461,7 +8582,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8472,25 +8593,25 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8578,8 +8699,8 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -8637,8 +8758,8 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -8686,7 +8807,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   border: 0;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8698,8 +8819,8 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -8718,64 +8839,45 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   flex: 1 0 auto;
 }
 
-.c11 > svg {
+.c10 > svg {
   vertical-align: bottom;
 }
 
-.c11:hover {
+.c10:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c10 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c10:hover {
-  padding: 4px;
-}
-
-.c10 > svg {
   vertical-align: middle;
 }
 
@@ -8797,7 +8899,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   min-width: 36px;
 }
 
-.c13 {
+.c12 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
@@ -8868,7 +8970,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c10"
+            class="c9 c6"
             type="button"
           >
             1
@@ -8882,7 +8984,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
         >
           <button
             aria-label="Go to page 2"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             2
@@ -8896,7 +8998,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
         >
           <button
             aria-label="Go to page 3"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             3
@@ -8909,7 +9011,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
           class="c4"
         >
           <span
-            class="c12 c13"
+            class="c11 c12"
           >
             …
           </span>
@@ -8922,7 +9024,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
         >
           <button
             aria-label="Go to page 24"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             24
@@ -8936,12 +9038,12 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
         >
           <button
             aria-label="Go to next page"
-            class="c11 c10"
+            class="c10 c6"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline
@@ -8995,7 +9097,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -9006,25 +9108,25 @@ exports[`Pagination should set page to last page if page prop > total possible
   stroke: #666666;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -9112,8 +9214,8 @@ exports[`Pagination should set page to last page if page prop > total possible
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   color: #000000;
@@ -9174,8 +9276,8 @@ exports[`Pagination should set page to last page if page prop > total possible
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
@@ -9235,8 +9337,8 @@ exports[`Pagination should set page to last page if page prop > total possible
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
+  border-radius: 4px;
+  padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
   text-align: center;
@@ -9286,30 +9388,11 @@ exports[`Pagination should set page to last page if page prop > total possible
 }
 
 .c6 {
-  padding: 4px;
   font-size: 18px;
   line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c6:hover {
-  padding: 4px;
 }
 
 .c6 > svg {
-  vertical-align: middle;
-}
-
-.c13 {
-  padding: 4px;
-  font-size: 18px;
-  line-height: 24px;
-  border-radius: 4px;
-  border-width: 2px;
-}
-
-.c13 > svg {
   vertical-align: middle;
 }
 
@@ -9497,13 +9580,13 @@ exports[`Pagination should set page to last page if page prop > total possible
           <button
             aria-disabled="true"
             aria-label="Go to next page"
-            class="c12 c13"
+            class="c12 c6"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <polyline

--- a/src/js/components/Pagination/doc.js
+++ b/src/js/components/Pagination/doc.js
@@ -92,105 +92,96 @@ export const themeDoc = {
     the pagination controls.`,
     type: 'string | (props) => {}',
   },
-  'pagination.control.extend': {
-    description: `Any additional style for each control.`,
-    type: 'string | (props) => {}',
-  },
-  'pagination.control.pad': {
-    description: `Padding around each control's label.`,
-    type: 'string | object',
-    defaultValue: '4px',
-  },
-  'pagination.control.size.small.border.radius': {
-    description: `Rounding of the corners for each control.`,
+  'pagination.button.size.small.border.radius': {
+    description: `Rounding of the corners for each button.`,
     type: 'string',
     defaultValue: '3px',
   },
-  'pagination.control.size.small.border.width': {
-    description: `Border thickness for each control.`,
+  'pagination.button.size.small.border.width': {
+    description: `Border thickness for each button.`,
     type: 'string',
     defaultValue: '2px',
   },
-  'pagination.control.size.small.font.size': {
-    description: `The font size of each control's label.`,
+  'pagination.button.size.small.font.size': {
+    description: `The font size of each button's label.`,
     type: 'string',
     defaultValue: '14px',
   },
-  'pagination.control.size.small.font.height': {
-    description: `The line-height of each control's label.`,
+  'pagination.button.size.small.font.height': {
+    description: `The line-height of each button's label.`,
     type: 'string',
     defaultValue: '20px',
   },
-  'pagination.control.size.small.height': {
-    description: `The height for each control.`,
+  'pagination.button.size.small.height': {
+    description: `The height for each button.`,
     type: 'string',
     defaultValue: '30px',
   },
-  'pagination.control.size.small.width': {
-    description: `The minimum width for each control. 
-    Width will scale up fitting the control's label.`,
+  'pagination.button.size.small.width': {
+    description: `The minimum width for each button. 
+    Width will scale up fitting the button's label.`,
     type: 'string',
     defaultValue: '30px',
   },
-  'pagination.control.size.medium.border.radius': {
-    description: `Rounding of the corners for each control.`,
+  'pagination.button.size.medium.border.radius': {
+    description: `Rounding of the corners for each button.`,
     type: 'string',
     defaultValue: '4px',
   },
-  'pagination.control.size.medium.border.width': {
-    description: `Border thickness for each control.`,
+  'pagination.button.size.medium.border.width': {
+    description: `Border thickness for each button.`,
     type: 'string',
     defaultValue: '2px',
   },
-  'pagination.control.size.medium.font.size': {
-    description: `The font size of each control's label.`,
+  'pagination.button.size.medium.font.size': {
+    description: `The font size of each button's label.`,
     type: 'string',
     defaultValue: '18px',
   },
-  'pagination.control.size.medium.font.height': {
-    description: `The line-height of each control's label.`,
+  'pagination.button.size.medium.font.height': {
+    description: `The line-height of each button's label.`,
     type: 'string',
     defaultValue: '24px',
   },
-  'pagination.control.size.medium.height': {
-    description: `The height for each control.`,
+  'pagination.button.size.medium.height': {
+    description: `The height for each button.`,
     type: 'string',
     defaultValue: '36px',
   },
-  'pagination.control.size.medium.width': {
-    description: `The minimum width for each control. 
-    Width will scale up fitting the control's label.`,
+  'pagination.button.size.medium.width': {
+    description: `The minimum width for each button. 
+    Width will scale up fitting the button's label.`,
     type: 'string',
     defaultValue: '36px',
   },
-  'pagination.control.size.large.border.radius': {
-    description: `Rounding of the corners for each control.`,
+  'pagination.button.size.large.border.radius': {
+    description: `Rounding of the corners for each button.`,
     type: 'string',
     defaultValue: '4px',
   },
-  'pagination.control.size.large.border.width': {
-    description: `Border thickness for each control.`,
+  'pagination.button.size.large.border.width': {
+    description: `Border thickness for each button.`,
     type: 'string',
     defaultValue: '6px',
   },
-  'pagination.control.size.large.font.size': {
-    description: `The font size of each control's label.`,
+  'pagination.button.size.large.font.size': {
+    description: `The font size of each button's label.`,
     type: 'string',
     defaultValue: '22px',
   },
-  'pagination.control.size.large.font.height': {
-    description: `The line-height of each control's label.`,
+  'pagination.button.size.large.font.height': {
+    description: `The line-height of each button's label.`,
     type: 'string',
     defaultValue: '28px',
   },
-  'pagination.control.size.large.height': {
-    description: `The height for each control.`,
+  'pagination.button.size.large.height': {
+    description: `The height for each button.`,
     type: 'string',
     defaultValue: '48px',
   },
-  'pagination.control.size.large.width': {
-    description: `The minimum width for each control. 
-    Width will scale up fitting the control's label.`,
+  'pagination.button.size.large.width': {
+    description: `The minimum width for each button. 
+    Width will scale up fitting the button's label.`,
     type: 'string',
     defaultValue: '48px',
   },

--- a/src/js/components/Pagination/doc.js
+++ b/src/js/components/Pagination/doc.js
@@ -62,25 +62,64 @@ export const doc = Pagination => {
 };
 
 export const themeDoc = {
-  'pagination.button.active.background.color': {
-    description: `Background color when the button is active.`,
-    type: 'string | { dark: string, light: string }',
-    defaultValue: 'active-background',
-  },
-  'pagination.button.color': {
-    description: `The color of the text label.`,
-    type: 'string | { dark: string, light: string }',
-    defaultValue: 'text-strong',
-  },
-  'pagination.button.hover.background.color': {
-    description: 'Background color of the button when hovered.',
-    type: 'string | { dark: string, light: string }',
-    defaultValue: 'background-contrast',
-  },
-  'pagination.button.hover.color': {
-    description: 'The color of the text label when hovered.',
-    type: 'string | { dark: string, light: string }',
-    defaultValue: undefined,
+  'pagination.button': {
+    description: 'Any valid Button theming to apply on the pagination buttons.',
+    type: 'object',
+    defaultValue: `{
+      active: {
+        background: {
+          color: 'active-background',
+        },
+      },
+      color: 'text-strong',
+      hover: {
+        background: {
+          color: 'background-contrast',
+        },
+        color: undefined,
+      },
+      size: {
+        small: {
+          border: {
+            radius: 3px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 14px,
+          height: 30px,
+          width: 30px,
+        },
+        medium: {
+          border: {
+            radius: 4px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 18px,
+          height: 36px,
+          width: 36px,
+        },
+        large: {
+          border: {
+            radius: 6px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 22px,
+          height: 48px,
+          width: 48px,
+        },
+      },
+    }`,
   },
   'pagination.container': {
     description: `Any valid Box props for the Box wrapping the 
@@ -91,99 +130,6 @@ export const themeDoc = {
     description: `Any additional style for the Box wrapping 
     the pagination controls.`,
     type: 'string | (props) => {}',
-  },
-  'pagination.button.size.small.border.radius': {
-    description: `Rounding of the corners for each button.`,
-    type: 'string',
-    defaultValue: '3px',
-  },
-  'pagination.button.size.small.border.width': {
-    description: `Border thickness for each button.`,
-    type: 'string',
-    defaultValue: '2px',
-  },
-  'pagination.button.size.small.font.size': {
-    description: `The font size of each button's label.`,
-    type: 'string',
-    defaultValue: '14px',
-  },
-  'pagination.button.size.small.font.height': {
-    description: `The line-height of each button's label.`,
-    type: 'string',
-    defaultValue: '20px',
-  },
-  'pagination.button.size.small.height': {
-    description: `The height for each button.`,
-    type: 'string',
-    defaultValue: '30px',
-  },
-  'pagination.button.size.small.width': {
-    description: `The minimum width for each button. 
-    Width will scale up fitting the button's label.`,
-    type: 'string',
-    defaultValue: '30px',
-  },
-  'pagination.button.size.medium.border.radius': {
-    description: `Rounding of the corners for each button.`,
-    type: 'string',
-    defaultValue: '4px',
-  },
-  'pagination.button.size.medium.border.width': {
-    description: `Border thickness for each button.`,
-    type: 'string',
-    defaultValue: '2px',
-  },
-  'pagination.button.size.medium.font.size': {
-    description: `The font size of each button's label.`,
-    type: 'string',
-    defaultValue: '18px',
-  },
-  'pagination.button.size.medium.font.height': {
-    description: `The line-height of each button's label.`,
-    type: 'string',
-    defaultValue: '24px',
-  },
-  'pagination.button.size.medium.height': {
-    description: `The height for each button.`,
-    type: 'string',
-    defaultValue: '36px',
-  },
-  'pagination.button.size.medium.width': {
-    description: `The minimum width for each button. 
-    Width will scale up fitting the button's label.`,
-    type: 'string',
-    defaultValue: '36px',
-  },
-  'pagination.button.size.large.border.radius': {
-    description: `Rounding of the corners for each button.`,
-    type: 'string',
-    defaultValue: '4px',
-  },
-  'pagination.button.size.large.border.width': {
-    description: `Border thickness for each button.`,
-    type: 'string',
-    defaultValue: '6px',
-  },
-  'pagination.button.size.large.font.size': {
-    description: `The font size of each button's label.`,
-    type: 'string',
-    defaultValue: '22px',
-  },
-  'pagination.button.size.large.font.height': {
-    description: `The line-height of each button's label.`,
-    type: 'string',
-    defaultValue: '28px',
-  },
-  'pagination.button.size.large.height': {
-    description: `The height for each button.`,
-    type: 'string',
-    defaultValue: '48px',
-  },
-  'pagination.button.size.large.width': {
-    description: `The minimum width for each button. 
-    Width will scale up fitting the button's label.`,
-    type: 'string',
-    defaultValue: '48px',
   },
   'pagination.controls.align': {
     description: `How the pagination controls should be aligned 

--- a/src/js/components/Pagination/stories/typescript/Custom.tsx
+++ b/src/js/components/Pagination/stories/typescript/Custom.tsx
@@ -1,15 +1,25 @@
 import React from 'react';
 
-import { Box, Grommet, Pagination, Text, ThemeContext } from 'grommet';
-import { grommet } from 'grommet/themes';
-import { deepMerge } from 'grommet/utils';
+import { Box, Grommet, Pagination, Text } from 'grommet';
+import { ThemeType } from 'grommet/themes';
 import { FormPreviousLink } from 'grommet-icons/icons/FormPreviousLink';
 import { FormNextLink } from 'grommet-icons/icons/FormNextLink';
 
-const customTheme = deepMerge(grommet, {
+// Type annotations can only be used in TypeScript files.
+// Remove ': ThemeType' if you are not using Typescript.
+const customTheme: ThemeType = {
+  global: {
+    font: {
+      family: 'Arial',
+    },
+  },
   pagination: {
     button: {
       color: 'text-strong',
+      border: {
+        color: 'skyblue',
+        width: '3px',
+      },
       active: {
         background: {
           color: 'salmon',
@@ -30,41 +40,7 @@ const customTheme = deepMerge(grommet, {
       previous: FormPreviousLink,
     },
   },
-});
-
-const secondaryTheme = deepMerge(grommet, {
-  button: {
-    default: {},
-    bright: {
-      color: 'text-strong',
-      border: {
-        color: 'skyblue',
-        width: '2px',
-      },
-    },
-    active: {
-      bright: {
-        background: {
-          color: '#CA9CEA',
-        },
-        border: {
-          color: 'transparent',
-        },
-        color: 'text',
-      },
-    },
-    hover: {
-      bright: {
-        background: {
-          color: 'skyblue',
-        },
-      },
-    },
-  },
-  pagination: {
-    button: 'bright',
-  },
-});
+};
 
 export const Custom = () => (
   <Grommet theme={customTheme}>
@@ -72,43 +48,21 @@ export const Custom = () => (
       <Box
         align="start"
         pad={{ top: 'medium', bottom: 'medium', horizontal: 'medium' }}
-        gap="large"
       >
-        <>
-          <Text margin={{ bottom: 'small' }}>
-            Custom Theme via theme.pagination.button
-          </Text>
-          <Pagination numberItems={237} />
-        </>
-        <>
-          <Text margin={{ bottom: 'small' }}>
-            Reference Button Kind by string
-          </Text>
-          <ThemeContext.Extend value={secondaryTheme}>
-            <Pagination numberItems={237} />
-          </ThemeContext.Extend>
-        </>
+        <Text margin={{ bottom: 'small' }}>
+          Custom Theme via theme.pagination.button
+        </Text>
+        <Pagination numberItems={237} />
       </Box>
       <Box
         align="start"
         background="black"
         pad={{ top: 'medium', bottom: 'medium', horizontal: 'medium' }}
-        gap="large"
       >
-        <>
-          <Text margin={{ bottom: 'small' }}>
-            Custom Theme via theme.pagination.button
-          </Text>
-          <Pagination numberItems={237} />
-        </>
-        <>
-          <Text margin={{ bottom: 'small' }}>
-            Reference Button Kind by string
-          </Text>
-          <ThemeContext.Extend value={secondaryTheme}>
-            <Pagination numberItems={237} />
-          </ThemeContext.Extend>
-        </>
+        <Text margin={{ bottom: 'small' }}>
+          Custom Theme via theme.pagination.button
+        </Text>
+        <Pagination numberItems={237} />
       </Box>
     </Box>
   </Grommet>

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12801,44 +12801,68 @@ nav
 \`\`\`
 ## Theme
   
-**pagination.button.active.background.color**
+**pagination.button**
 
-Background color when the button is active. Expects \`string | { dark: string, light: string }\`.
-
-Defaults to
-
-\`\`\`
-active-background
-\`\`\`
-
-**pagination.button.color**
-
-The color of the text label. Expects \`string | { dark: string, light: string }\`.
+Any valid Button theming to apply on the pagination buttons. Expects \`object\`.
 
 Defaults to
 
 \`\`\`
-text-strong
-\`\`\`
-
-**pagination.button.hover.background.color**
-
-Background color of the button when hovered. Expects \`string | { dark: string, light: string }\`.
-
-Defaults to
-
-\`\`\`
-background-contrast
-\`\`\`
-
-**pagination.button.hover.color**
-
-The color of the text label when hovered. Expects \`string | { dark: string, light: string }\`.
-
-Defaults to
-
-\`\`\`
-undefined
+{
+      active: {
+        background: {
+          color: 'active-background',
+        },
+      },
+      color: 'text-strong',
+      hover: {
+        background: {
+          color: 'background-contrast',
+        },
+        color: undefined,
+      },
+      size: {
+        small: {
+          border: {
+            radius: 3px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 14px,
+          height: 30px,
+          width: 30px,
+        },
+        medium: {
+          border: {
+            radius: 4px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 18px,
+          height: 36px,
+          width: 36px,
+        },
+        large: {
+          border: {
+            radius: 6px,
+            width: 2px,
+          },
+          pad: {
+            vertical: 4px,
+            horizontal: 4px,
+          },
+          font: 22px,
+          height: 48px,
+          width: 48px,
+        },
+      },
+    }
 \`\`\`
 
 **pagination.container**
@@ -12861,189 +12885,6 @@ Defaults to
 
 \`\`\`
 undefined
-\`\`\`
-
-**pagination.button.size.small.border.radius**
-
-Rounding of the corners for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-3px
-\`\`\`
-
-**pagination.button.size.small.border.width**
-
-Border thickness for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-2px
-\`\`\`
-
-**pagination.button.size.small.font.size**
-
-The font size of each button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-14px
-\`\`\`
-
-**pagination.button.size.small.font.height**
-
-The line-height of each button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-20px
-\`\`\`
-
-**pagination.button.size.small.height**
-
-The height for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-30px
-\`\`\`
-
-**pagination.button.size.small.width**
-
-The minimum width for each button. 
-    Width will scale up fitting the button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-30px
-\`\`\`
-
-**pagination.button.size.medium.border.radius**
-
-Rounding of the corners for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-4px
-\`\`\`
-
-**pagination.button.size.medium.border.width**
-
-Border thickness for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-2px
-\`\`\`
-
-**pagination.button.size.medium.font.size**
-
-The font size of each button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-18px
-\`\`\`
-
-**pagination.button.size.medium.font.height**
-
-The line-height of each button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-24px
-\`\`\`
-
-**pagination.button.size.medium.height**
-
-The height for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-36px
-\`\`\`
-
-**pagination.button.size.medium.width**
-
-The minimum width for each button. 
-    Width will scale up fitting the button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-36px
-\`\`\`
-
-**pagination.button.size.large.border.radius**
-
-Rounding of the corners for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-4px
-\`\`\`
-
-**pagination.button.size.large.border.width**
-
-Border thickness for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-6px
-\`\`\`
-
-**pagination.button.size.large.font.size**
-
-The font size of each button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-22px
-\`\`\`
-
-**pagination.button.size.large.font.height**
-
-The line-height of each button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-28px
-\`\`\`
-
-**pagination.button.size.large.height**
-
-The height for each button. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-48px
-\`\`\`
-
-**pagination.button.size.large.width**
-
-The minimum width for each button. 
-    Width will scale up fitting the button's label. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-48px
 \`\`\`
 
 **pagination.controls.align**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12863,29 +12863,9 @@ Defaults to
 undefined
 \`\`\`
 
-**pagination.control.extend**
+**pagination.button.size.small.border.radius**
 
-Any additional style for each control. Expects \`string | (props) => {}\`.
-
-Defaults to
-
-\`\`\`
-undefined
-\`\`\`
-
-**pagination.control.pad**
-
-Padding around each control's label. Expects \`string | object\`.
-
-Defaults to
-
-\`\`\`
-4px
-\`\`\`
-
-**pagination.control.size.small.border.radius**
-
-Rounding of the corners for each control. Expects \`string\`.
+Rounding of the corners for each button. Expects \`string\`.
 
 Defaults to
 
@@ -12893,9 +12873,9 @@ Defaults to
 3px
 \`\`\`
 
-**pagination.control.size.small.border.width**
+**pagination.button.size.small.border.width**
 
-Border thickness for each control. Expects \`string\`.
+Border thickness for each button. Expects \`string\`.
 
 Defaults to
 
@@ -12903,9 +12883,9 @@ Defaults to
 2px
 \`\`\`
 
-**pagination.control.size.small.font.size**
+**pagination.button.size.small.font.size**
 
-The font size of each control's label. Expects \`string\`.
+The font size of each button's label. Expects \`string\`.
 
 Defaults to
 
@@ -12913,9 +12893,9 @@ Defaults to
 14px
 \`\`\`
 
-**pagination.control.size.small.font.height**
+**pagination.button.size.small.font.height**
 
-The line-height of each control's label. Expects \`string\`.
+The line-height of each button's label. Expects \`string\`.
 
 Defaults to
 
@@ -12923,20 +12903,9 @@ Defaults to
 20px
 \`\`\`
 
-**pagination.control.size.small.height**
+**pagination.button.size.small.height**
 
-The height for each control. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-30px
-\`\`\`
-
-**pagination.control.size.small.width**
-
-The minimum width for each control. 
-    Width will scale up fitting the control's label. Expects \`string\`.
+The height for each button. Expects \`string\`.
 
 Defaults to
 
@@ -12944,9 +12913,20 @@ Defaults to
 30px
 \`\`\`
 
-**pagination.control.size.medium.border.radius**
+**pagination.button.size.small.width**
 
-Rounding of the corners for each control. Expects \`string\`.
+The minimum width for each button. 
+    Width will scale up fitting the button's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+30px
+\`\`\`
+
+**pagination.button.size.medium.border.radius**
+
+Rounding of the corners for each button. Expects \`string\`.
 
 Defaults to
 
@@ -12954,9 +12934,9 @@ Defaults to
 4px
 \`\`\`
 
-**pagination.control.size.medium.border.width**
+**pagination.button.size.medium.border.width**
 
-Border thickness for each control. Expects \`string\`.
+Border thickness for each button. Expects \`string\`.
 
 Defaults to
 
@@ -12964,9 +12944,9 @@ Defaults to
 2px
 \`\`\`
 
-**pagination.control.size.medium.font.size**
+**pagination.button.size.medium.font.size**
 
-The font size of each control's label. Expects \`string\`.
+The font size of each button's label. Expects \`string\`.
 
 Defaults to
 
@@ -12974,9 +12954,9 @@ Defaults to
 18px
 \`\`\`
 
-**pagination.control.size.medium.font.height**
+**pagination.button.size.medium.font.height**
 
-The line-height of each control's label. Expects \`string\`.
+The line-height of each button's label. Expects \`string\`.
 
 Defaults to
 
@@ -12984,20 +12964,9 @@ Defaults to
 24px
 \`\`\`
 
-**pagination.control.size.medium.height**
+**pagination.button.size.medium.height**
 
-The height for each control. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-36px
-\`\`\`
-
-**pagination.control.size.medium.width**
-
-The minimum width for each control. 
-    Width will scale up fitting the control's label. Expects \`string\`.
+The height for each button. Expects \`string\`.
 
 Defaults to
 
@@ -13005,9 +12974,20 @@ Defaults to
 36px
 \`\`\`
 
-**pagination.control.size.large.border.radius**
+**pagination.button.size.medium.width**
 
-Rounding of the corners for each control. Expects \`string\`.
+The minimum width for each button. 
+    Width will scale up fitting the button's label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+36px
+\`\`\`
+
+**pagination.button.size.large.border.radius**
+
+Rounding of the corners for each button. Expects \`string\`.
 
 Defaults to
 
@@ -13015,9 +12995,9 @@ Defaults to
 4px
 \`\`\`
 
-**pagination.control.size.large.border.width**
+**pagination.button.size.large.border.width**
 
-Border thickness for each control. Expects \`string\`.
+Border thickness for each button. Expects \`string\`.
 
 Defaults to
 
@@ -13025,9 +13005,9 @@ Defaults to
 6px
 \`\`\`
 
-**pagination.control.size.large.font.size**
+**pagination.button.size.large.font.size**
 
-The font size of each control's label. Expects \`string\`.
+The font size of each button's label. Expects \`string\`.
 
 Defaults to
 
@@ -13035,9 +13015,9 @@ Defaults to
 22px
 \`\`\`
 
-**pagination.control.size.large.font.height**
+**pagination.button.size.large.font.height**
 
-The line-height of each control's label. Expects \`string\`.
+The line-height of each button's label. Expects \`string\`.
 
 Defaults to
 
@@ -13045,9 +13025,9 @@ Defaults to
 28px
 \`\`\`
 
-**pagination.control.size.large.height**
+**pagination.button.size.large.height**
 
-The height for each control. Expects \`string\`.
+The height for each button. Expects \`string\`.
 
 Defaults to
 
@@ -13055,10 +13035,10 @@ Defaults to
 48px
 \`\`\`
 
-**pagination.control.size.large.width**
+**pagination.button.size.large.width**
 
-The minimum width for each control. 
-    Width will scale up fitting the control's label. Expects \`string\`.
+The minimum width for each button. 
+    Width will scale up fitting the button's label. Expects \`string\`.
 
 Defaults to
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -144,6 +144,70 @@ interface ButtonKindType {
   extend?: ExtendType;
 }
 
+interface ButtonType {
+  border?: {
+    color?: ColorType;
+    width?: string;
+    radius?: string;
+  };
+  color?: ColorType;
+  extend?: ExtendType;
+  minWidth?: string;
+  maxWidth?: string;
+  padding?: {
+    vertical?: string;
+    horizontal?: string;
+  };
+  default?: ButtonKindType;
+  primary?: ButtonKindType;
+  secondary?: ButtonKindType;
+  option?: ButtonKindType;
+  active?: ButtonKindType & {
+    default?: ButtonKindType;
+    primary?: ButtonKindType;
+    secondary?: ButtonKindType;
+  };
+  disabled?: ButtonKindType & { opacity?: OpacityType };
+  hover?: ButtonKindType & {
+    default?: ButtonKindType;
+    primary?: ButtonKindType;
+    secondary?: ButtonKindType;
+  };
+  size?: {
+    small?: {
+      border?: {
+        radius?: string;
+      };
+      pad?: {
+        vertical?: string;
+        horizontal?: string;
+      };
+    };
+    medium?: {
+      border?: {
+        radius?: string;
+      };
+      pad?: {
+        vertical?: string;
+        horizontal?: string;
+      };
+    };
+    large?: {
+      border?: {
+        radius?: string;
+      };
+      pad?: {
+        vertical?: string;
+        horizontal?: string;
+      };
+    };
+  };
+  transition?: {
+    timing?: string;
+    duration?: number;
+    properties?: string[];
+  };
+}
 interface FormFieldLabelType extends TextProps {
   requiredIndicator?: boolean | JSX.Element | string;
 }
@@ -381,70 +445,7 @@ export interface ThemeType {
     extend?: ExtendType;
     responsiveBreakpoint?: string;
   };
-  button?: {
-    border?: {
-      color?: ColorType;
-      width?: string;
-      radius?: string;
-    };
-    color?: ColorType;
-    extend?: ExtendType;
-    minWidth?: string;
-    maxWidth?: string;
-    padding?: {
-      vertical?: string;
-      horizontal?: string;
-    };
-    default?: ButtonKindType;
-    primary?: ButtonKindType;
-    secondary?: ButtonKindType;
-    option?: ButtonKindType;
-    active?: ButtonKindType & {
-      default?: ButtonKindType;
-      primary?: ButtonKindType;
-      secondary?: ButtonKindType;
-    };
-    disabled?: ButtonKindType & { opacity?: OpacityType };
-    hover?: ButtonKindType & {
-      default?: ButtonKindType;
-      primary?: ButtonKindType;
-      secondary?: ButtonKindType;
-    };
-    size?: {
-      small?: {
-        border?: {
-          radius?: string;
-        };
-        pad?: {
-          vertical?: string;
-          horizontal?: string;
-        };
-      };
-      medium?: {
-        border?: {
-          radius?: string;
-        };
-        pad?: {
-          vertical?: string;
-          horizontal?: string;
-        };
-      };
-      large?: {
-        border?: {
-          radius?: string;
-        };
-        pad?: {
-          vertical?: string;
-          horizontal?: string;
-        };
-      };
-    };
-    transition?: {
-      timing?: string;
-      duration?: number;
-      properties?: string[];
-    };
-  };
+  button?: ButtonType;
   calendar?: {
     day?: {
       extend?: ExtendType;
@@ -957,63 +958,8 @@ export interface ThemeType {
     extend?: ExtendType;
   };
   pagination?: {
-    button?: {
-      active?: {
-        background?: {
-          color?: ColorType;
-        };
-      };
-      color?: ColorType;
-      hover?: {
-        background?: {
-          color?: ColorType;
-        };
-        color?: ColorType;
-      };
-    };
+    button?: ButtonType;
     container?: BoxProps;
-    control?: {
-      extend?: ExtendType;
-      pad?: PadType;
-      size?: {
-        small?: {
-          border?: {
-            radius?: string;
-            width?: string;
-          };
-          font?: {
-            size?: string;
-            height?: string;
-          };
-          height?: string;
-          width?: string;
-        };
-        medium?: {
-          border?: {
-            radius?: string;
-            width?: string;
-          };
-          font?: {
-            size?: string;
-            height?: string;
-          };
-          height?: string;
-          width?: string;
-        };
-        large?: {
-          border?: {
-            radius?: string;
-            width?: string;
-          };
-          font?: {
-            size?: string;
-            height?: string;
-          };
-          height?: string;
-          width?: string;
-        };
-      };
-    };
     controls?: {
       align?: AlignContentType;
       direction?: DirectionType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -972,19 +972,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           },
           color: undefined,
         },
-      },
-      // container: {
-      //   // any box props,
-      //   extend: undefined,
-      // },
-      control: {
-        // extend: undefined,
-        pad: '4px',
         size: {
           small: {
             border: {
               radius: `${baseSpacing / 8}px`, // 3
               width: '2px',
+            },
+            pad: {
+              vertical: `4px`,
+              horizontal: `4px`,
             },
             font: { ...fontSizing(-1) },
             height: `${baseSpacing * 1.25}px`,
@@ -995,6 +991,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
               radius: `${baseSpacing / 6}px`, // 4
               width: '2px',
             },
+            pad: {
+              vertical: `4px`,
+              horizontal: `4px`,
+            },
             font: { ...fontSizing(0) },
             height: `${baseSpacing * 1.5}px`,
             width: `${baseSpacing * 1.5}px`,
@@ -1004,12 +1004,20 @@ export const generate = (baseSpacing = 24, scale = 6) => {
               radius: `${baseSpacing / 4}px`, // 6
               width: '2px',
             },
+            pad: {
+              vertical: `4px`,
+              horizontal: `4px`,
+            },
             font: { ...fontSizing(1) },
             height: `${baseSpacing * 2}px`,
             width: `${baseSpacing * 2}px`,
           },
         },
       },
+      // container: {
+      //   // any box props,
+      //   extend: undefined,
+      // },
       controls: {
         align: 'center',
         direction: 'row',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Moves theming that had been under `theme.pagination.control` to `theme.pagination.button`.
- Adjusted `StyledButtonKind` to account for themeObj that are referencing somewhere other than `theme.button`.
- Updates docs
- Updates Typescript definitions
- Updates base.js & base.d.ts

#### Where should the reviewer start?
src/js/components/Pagination/PageControl.js

#### What testing has been done on this PR?
Tested in storybook, looked at snapshot changes.

#### How should this be manually tested?
Check Custom Pagination storybook example or try locally.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
